### PR TITLE
feat: add configurable workflows location (project dir / workflows dir)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ vendor/bin/github-actions-matrix compare [options]
 - `-r, --repo=REPO` - The name of the GitHub repository
 - `-b, --branch=BRANCH` - The branch to compare
 - `-t, --token=TOKEN` - Your GitHub access token
+- `-p, --project-dir=PROJECT-DIR` - The project root that contains the `.github/workflows` folder
+- `-w, --workflows-dir=WORKFLOWS-DIR` - The folder that directly contains the workflow `*.yml` files (non-standard layouts)
 
 **Example:**
 ```bash
@@ -106,6 +108,8 @@ vendor/bin/github-actions-matrix sync [options]
 - `-r, --repo=REPO` - The name of the GitHub repository
 - `-b, --branch=BRANCH` - The branch to sync
 - `-t, --token=TOKEN` - Your GitHub access token
+- `-p, --project-dir=PROJECT-DIR` - The project root that contains the `.github/workflows` folder
+- `-w, --workflows-dir=WORKFLOWS-DIR` - The folder that directly contains the workflow `*.yml` files (non-standard layouts)
 
 **Example:**
 ```bash
@@ -148,20 +152,32 @@ To avoid repeatedly providing the same options, you can create a configuration f
 
 The commands use the following priority order to determine values:
 
-1. **CLI options** (highest priority) - `--username`, `--repo`, `--branch`
+1. **CLI options** (highest priority) - `--username`, `--repo`, `--branch`, `--project-dir`, `--workflows-dir`
 2. **Configuration file** - values from `gh-actions-matrix.php`
-3. **Git configuration** - for username and repo-name, read from git config/remote
-4. **Auto-selection** - for branch only, if there's only one protected branch
+3. **Git configuration** - for username and repo-name, read from git config/remote; for the workflows location, the git root
+4. **Inference / auto-selection** - for branch, if there's only one protected branch; for the workflows location, the tool's own `__DIR__` fallbacks
 5. **Interactive prompt** (lowest priority) - asks for missing values
+
+#### Workflows Location Resolution
+
+By default the tool discovers the `.github/workflows` folder by inference (git root, then its own `__DIR__`). In a monorepo, or a `type: path` install where the tool runs from a sub-project (e.g. `backend/`) and cannot infer the location, declare it explicitly. The first **existing** folder in this chain wins:
+
+1. `--workflows-dir` (CLI)
+2. `setWorkflowsDir()` (config)
+3. `--project-dir` (CLI) → `<project-dir>/.github/workflows`
+4. `setProjectDir()` (config) → `<projectDir>/.github/workflows`
+5. The **git root** (`git rev-parse --show-toplevel`) → `<root>/.github/workflows`
+6. The tool's own `__DIR__` fallbacks (the historical behaviour)
+
+`setProjectDir()` is the primary, intuitive concept (the project root that contains `.github/workflows`); `setWorkflowsDir()` is the escape hatch for a non-standard layout. With nothing declared, behaviour is identical to before.
 
 #### Token File Resolution
 
 The `setTokenFile()` path is resolved against the first available base directory in this chain:
 
-1. The **git root** (`git rev-parse --show-toplevel`) — when git is available.
-2. The **current working directory** — fallback for containerised or non-git environments.
-
-> **Note:** A future release will add `setProjectDir()` as the highest-priority base, prepending it to this chain.
+1. The **configured project dir** (`setProjectDir()`) — when set.
+2. The **git root** (`git rev-parse --show-toplevel`) — when git is available.
+3. The **current working directory** — fallback for containerised or non-git environments.
 
 #### Benefits
 

--- a/gh-actions-matrix.dist.php
+++ b/gh-actions-matrix.dist.php
@@ -23,8 +23,17 @@ $config = new Aerendir\Bin\GitHubActionsMatrix\Config\GHMatrixConfig();
 // $config->setRepoName('your-repo-name');
 
 // Set the name of the file that contains the GitHub token.
-// The file is resolved relative to: the git root (when available), or the current working directory.
-// When issue #38 adds setProjectDir(), the project dir will be tried first.
+// The file is resolved relative to: the configured project dir (see setProjectDir() below, when set),
+// then the git root (when available), then the current working directory.
 // $config->setTokenFile('gh_token');
+
+// Set the project root that contains the ".github/workflows" folder.
+// Useful in a monorepo or a "type: path" install where the tool runs from a sub-project (e.g. backend/)
+// and cannot infer the location from git or its own __DIR__. It is also the preferred base for the token file.
+// $config->setProjectDir('/srv/app');
+
+// Set the folder that directly contains the workflow "*.yml" files.
+// Escape hatch for non-standard layouts where the workflows do NOT live under "<projectDir>/.github/workflows".
+// $config->setWorkflowsDir('/srv/app/.github/workflows');
 
 return $config;

--- a/src/Config/GHMatrixConfig.php
+++ b/src/Config/GHMatrixConfig.php
@@ -15,10 +15,12 @@ namespace Aerendir\Bin\GitHubActionsMatrix\Config;
 
 final class GHMatrixConfig
 {
-    private ?string $user      = null;
-    private ?string $branch    = null;
-    private ?string $repoName  = null;
-    private ?string $tokenFile = null;
+    private ?string $user         = null;
+    private ?string $branch       = null;
+    private ?string $repoName     = null;
+    private ?string $tokenFile    = null;
+    private ?string $projectDir   = null;
+    private ?string $workflowsDir = null;
 
     /** @var array<string, array<array<string, string>>> */
     private array $optionalCombinations = [];
@@ -61,6 +63,36 @@ final class GHMatrixConfig
     public function setTokenFile(?string $tokenFile): void
     {
         $this->tokenFile = $tokenFile;
+    }
+
+    public function getProjectDir(): ?string
+    {
+        return $this->projectDir;
+    }
+
+    /**
+     * The project root that contains the `.github/workflows` folder.
+     *
+     * Used both to locate the workflows and as the preferred base directory to resolve the token file.
+     */
+    public function setProjectDir(?string $projectDir): void
+    {
+        $this->projectDir = $projectDir;
+    }
+
+    public function getWorkflowsDir(): ?string
+    {
+        return $this->workflowsDir;
+    }
+
+    /**
+     * The folder that directly contains the workflow `*.yml` files.
+     *
+     * Escape hatch for non-standard layouts where the workflows do not live under `<projectDir>/.github/workflows`.
+     */
+    public function setWorkflowsDir(?string $workflowsDir): void
+    {
+        $this->workflowsDir = $workflowsDir;
     }
 
     /**

--- a/src/Console/Command/AbstractCommand.php
+++ b/src/Console/Command/AbstractCommand.php
@@ -16,11 +16,14 @@ namespace Aerendir\Bin\GitHubActionsMatrix\Console\Command;
 use Aerendir\Bin\GitHubActionsMatrix\Config\GHMatrixConfig;
 use Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options\GitHubTokenCommandOption;
 use Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options\GitHubUsernameCommandOption;
+use Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options\ProjectDirCommandOption;
 use Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options\RepoBranchCommandOption;
 use Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options\RepoNameCommandOption;
+use Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options\WorkflowsDirCommandOption;
 use Aerendir\Bin\GitHubActionsMatrix\Repo\Reader as RepoReader;
 use Aerendir\Bin\GitHubActionsMatrix\ValueObject\JobsCollection;
 use Aerendir\Bin\GitHubActionsMatrix\Workflow\Comparator;
+use Aerendir\Bin\GitHubActionsMatrix\Workflow\Finder;
 use Aerendir\Bin\GitHubActionsMatrix\Workflow\Reader as WorkflowsReader;
 use Github\Api\Repo;
 use Github\Api\Repository\Protection;
@@ -46,9 +49,10 @@ abstract class AbstractCommand extends Command
     private readonly GitHubTokenCommandOption $gitHubTokenCommandOption;
     private readonly RepoBranchCommandOption $repoBranchCommandOption;
     private readonly RepoNameCommandOption $repoNameCommandOption;
+    private readonly ProjectDirCommandOption $projectDirCommandOption;
+    private readonly WorkflowsDirCommandOption $workflowsDirCommandOption;
     private readonly Client $githubClient;
     private readonly RepoReader $repoReader;
-    private readonly WorkflowsReader $workflowsReader;
     private readonly Comparator $comparator;
     private string $repoUsername;
     private string $repoName;
@@ -64,9 +68,12 @@ abstract class AbstractCommand extends Command
         ?RepoBranchCommandOption $repoBranchCommandOption = null,
         ?RepoNameCommandOption $repoNameCommandOption = null,
         ?RepoReader $repoReader = null,
-        ?WorkflowsReader $workflowsReader = null,
+        // Built lazily in init() (so CLI options apply) when not explicitly injected (tests inject a mock).
+        private ?WorkflowsReader $workflowsReader = null,
         ?Comparator $comparator = null,
         ?Client $githubClient = null,
+        ?ProjectDirCommandOption $projectDirCommandOption = null,
+        ?WorkflowsDirCommandOption $workflowsDirCommandOption = null,
     ) {
         parent::__construct();
         $this->config                      = $config                      ?? new GHMatrixConfig();
@@ -74,8 +81,9 @@ abstract class AbstractCommand extends Command
         $this->gitHubTokenCommandOption    = $gitHubTokenCommandOption    ?? new GitHubTokenCommandOption();
         $this->repoBranchCommandOption     = $repoBranchCommandOption     ?? new RepoBranchCommandOption();
         $this->repoNameCommandOption       = $repoNameCommandOption       ?? new RepoNameCommandOption();
+        $this->projectDirCommandOption     = $projectDirCommandOption     ?? new ProjectDirCommandOption();
+        $this->workflowsDirCommandOption   = $workflowsDirCommandOption   ?? new WorkflowsDirCommandOption();
         $this->repoReader                  = $repoReader                  ?? new RepoReader();
-        $this->workflowsReader             = $workflowsReader             ?? new WorkflowsReader();
         $this->comparator                  = $comparator                  ?? new Comparator($this->config);
         $this->githubClient                = $githubClient                ?? Client::createWithHttpClient(new HttplugClient());
     }
@@ -87,6 +95,8 @@ abstract class AbstractCommand extends Command
         $this->addOption(GitHubTokenCommandOption::NAME, GitHubTokenCommandOption::SHORTCUT, InputOption::VALUE_REQUIRED, 'Your GitHub access token.');
         $this->addOption(RepoBranchCommandOption::NAME, RepoBranchCommandOption::SHORTCUT, InputOption::VALUE_REQUIRED, 'The branch for which the matrix has to be synchronized.');
         $this->addOption(RepoNameCommandOption::NAME, RepoNameCommandOption::SHORTCUT, InputOption::VALUE_REQUIRED, 'The name of the GitHub repository.');
+        $this->addOption(ProjectDirCommandOption::NAME, ProjectDirCommandOption::SHORTCUT, InputOption::VALUE_REQUIRED, 'The project root that contains the ".github/workflows" folder.');
+        $this->addOption(WorkflowsDirCommandOption::NAME, WorkflowsDirCommandOption::SHORTCUT, InputOption::VALUE_REQUIRED, 'The folder that directly contains the workflow "*.yml" files (non-standard layouts).');
     }
 
     protected function init(InputInterface $input, OutputInterface $output): void
@@ -102,6 +112,9 @@ abstract class AbstractCommand extends Command
         $repoToken      = $this->getRepoToken($input, $output, $questionHelper);
         $this->repoName = $this->getRepoName($input, $output, $questionHelper);
 
+        // Build the workflows reader lazily so CLI options (--project-dir/--workflows-dir) are honoured.
+        // When a reader was injected (e.g. a mock in tests), it is kept as-is.
+        $this->workflowsReader ??= new WorkflowsReader(new Finder($this->resolveWorkflowCandidates($input)));
         $this->localJobs = $this->workflowsReader->read();
 
         $this->githubClient->authenticate(tokenOrLogin: $repoToken, authMethod: AuthMethod::ACCESS_TOKEN);
@@ -318,25 +331,91 @@ abstract class AbstractCommand extends Command
     }
 
     /**
+     * Builds the ordered list of candidate folders where the workflows may live.
+     *
+     * Resolution order (first existing folder wins, handled by {@see Finder}):
+     *   1. `--workflows-dir` (CLI)
+     *   2. `GHMatrixConfig::getWorkflowsDir()` (config)
+     *   3. `--project-dir` (CLI)                → `<project-dir>/.github/workflows`
+     *   4. `GHMatrixConfig::getProjectDir()`    → `<projectDir>/.github/workflows`
+     *   5. git root (`RepoReader::getRepoRoot()`, wrapped) → `<root>/.github/workflows`
+     *   6. the existing `__DIR__` fallbacks (`Finder::FROM_VENDOR`, `Finder::FROM_VENDOR_BIN_VENDOR`)
+     *
+     * With nothing declared, the list is just the two `__DIR__` fallbacks: behaviour is identical to before.
+     *
+     * @return array<int, string>
+     */
+    private function resolveWorkflowCandidates(?InputInterface $input): array
+    {
+        $candidates = [];
+
+        // Priority 1: --workflows-dir (CLI)
+        $cliWorkflowsDir = null !== $input ? $this->workflowsDirCommandOption->getValueOrNull($input) : null;
+        if (null !== $cliWorkflowsDir) {
+            $candidates[] = $cliWorkflowsDir;
+        }
+
+        // Priority 2: GHMatrixConfig::getWorkflowsDir() (config)
+        $configWorkflowsDir = $this->config->getWorkflowsDir();
+        if (null !== $configWorkflowsDir) {
+            $candidates[] = $configWorkflowsDir;
+        }
+
+        // Priority 3: --project-dir (CLI) → <project-dir>/.github/workflows
+        $cliProjectDir = null !== $input ? $this->projectDirCommandOption->getValueOrNull($input) : null;
+        if (null !== $cliProjectDir) {
+            $candidates[] = $this->workflowsDirFromProjectDir($cliProjectDir);
+        }
+
+        // Priority 4: GHMatrixConfig::getProjectDir() (config) → <projectDir>/.github/workflows
+        $configProjectDir = $this->config->getProjectDir();
+        if (null !== $configProjectDir) {
+            $candidates[] = $this->workflowsDirFromProjectDir($configProjectDir);
+        }
+
+        // Priority 5: git root → <root>/.github/workflows
+        try {
+            $candidates[] = $this->workflowsDirFromProjectDir($this->repoReader->getRepoRoot());
+        } catch (\Throwable) {
+            // git not available or not in a git repository — fall through to the __DIR__ fallbacks
+        }
+
+        // Priority 6: the existing __DIR__ fallbacks (backward compatible)
+        $candidates[] = Finder::FROM_VENDOR;
+        $candidates[] = Finder::FROM_VENDOR_BIN_VENDOR;
+
+        return $candidates;
+    }
+
+    private function workflowsDirFromProjectDir(string $projectDir): string
+    {
+        return rtrim($projectDir, '/\\') . DIRECTORY_SEPARATOR . '.github' . DIRECTORY_SEPARATOR . 'workflows';
+    }
+
+    /**
      * Returns the base directory used to resolve the token file path.
      *
      * Resolution chain:
-     *   1. Git root (`RepoReader::getRepoRoot()`) — existing behaviour when git is available.
-     *   2. Current working directory (`getcwd()`) — fallback for environments without git.
-     *
-     * TODO: INSERTION POINT for issue #38 — when GHMatrixConfig::setProjectDir() is added,
-     *       prepend projectDir as the first candidate: projectDir → git root → cwd.
+     *   1. `GHMatrixConfig::getProjectDir()` — the configured project root (when set).
+     *   2. Git root (`RepoReader::getRepoRoot()`) — existing behaviour when git is available.
+     *   3. Current working directory (`getcwd()`) — fallback for environments without git.
      */
     private function resolveTokenBaseDir(): string
     {
-        // Priority 1: git root (existing behaviour, when available)
+        // Priority 1: configured project dir (preferred base, when set)
+        $projectDir = $this->config->getProjectDir();
+        if (null !== $projectDir) {
+            return $projectDir;
+        }
+
+        // Priority 2: git root (existing behaviour, when available)
         try {
             return $this->repoReader->getRepoRoot();
         } catch (\Throwable) {
             // git not available or not in a git repository — fall through
         }
 
-        // Priority 2: current working directory (where the config file is already loaded from)
+        // Priority 3: current working directory (where the config file is already loaded from)
         return getcwd();
     }
 }

--- a/src/Console/Command/AbstractCommand.php
+++ b/src/Console/Command/AbstractCommand.php
@@ -114,7 +114,8 @@ abstract class AbstractCommand extends Command
 
         // The candidate folders are resolved at run time (CLI options --project-dir/--workflows-dir, config,
         // git root) and passed to read(): the reader itself is a plain injected collaborator.
-        $this->localJobs = $this->workflowsReader->read($this->resolveWorkflowCandidates($input));
+        $workflowCandidates = $this->resolveWorkflowCandidates($input);
+        $this->localJobs    = $this->workflowsReader->read($workflowCandidates);
 
         $this->githubClient->authenticate(tokenOrLogin: $repoToken, authMethod: AuthMethod::ACCESS_TOKEN);
         $repo = $this->githubClient->api('repo');

--- a/src/Console/Command/AbstractCommand.php
+++ b/src/Console/Command/AbstractCommand.php
@@ -23,7 +23,6 @@ use Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options\WorkflowsDir
 use Aerendir\Bin\GitHubActionsMatrix\Repo\Reader as RepoReader;
 use Aerendir\Bin\GitHubActionsMatrix\ValueObject\JobsCollection;
 use Aerendir\Bin\GitHubActionsMatrix\Workflow\Comparator;
-use Aerendir\Bin\GitHubActionsMatrix\Workflow\Finder;
 use Aerendir\Bin\GitHubActionsMatrix\Workflow\Reader as WorkflowsReader;
 use Github\Api\Repo;
 use Github\Api\Repository\Protection;
@@ -53,6 +52,7 @@ abstract class AbstractCommand extends Command
     private readonly WorkflowsDirCommandOption $workflowsDirCommandOption;
     private readonly Client $githubClient;
     private readonly RepoReader $repoReader;
+    private readonly WorkflowsReader $workflowsReader;
     private readonly Comparator $comparator;
     private string $repoUsername;
     private string $repoName;
@@ -68,8 +68,7 @@ abstract class AbstractCommand extends Command
         ?RepoBranchCommandOption $repoBranchCommandOption = null,
         ?RepoNameCommandOption $repoNameCommandOption = null,
         ?RepoReader $repoReader = null,
-        // Built lazily in init() (so CLI options apply) when not explicitly injected (tests inject a mock).
-        private ?WorkflowsReader $workflowsReader = null,
+        ?WorkflowsReader $workflowsReader = null,
         ?Comparator $comparator = null,
         ?Client $githubClient = null,
         ?ProjectDirCommandOption $projectDirCommandOption = null,
@@ -84,6 +83,7 @@ abstract class AbstractCommand extends Command
         $this->projectDirCommandOption     = $projectDirCommandOption     ?? new ProjectDirCommandOption();
         $this->workflowsDirCommandOption   = $workflowsDirCommandOption   ?? new WorkflowsDirCommandOption();
         $this->repoReader                  = $repoReader                  ?? new RepoReader();
+        $this->workflowsReader             = $workflowsReader             ?? new WorkflowsReader();
         $this->comparator                  = $comparator                  ?? new Comparator($this->config);
         $this->githubClient                = $githubClient                ?? Client::createWithHttpClient(new HttplugClient());
     }
@@ -112,10 +112,9 @@ abstract class AbstractCommand extends Command
         $repoToken      = $this->getRepoToken($input, $output, $questionHelper);
         $this->repoName = $this->getRepoName($input, $output, $questionHelper);
 
-        // Build the workflows reader lazily so CLI options (--project-dir/--workflows-dir) are honoured.
-        // When a reader was injected (e.g. a mock in tests), it is kept as-is.
-        $this->workflowsReader ??= new WorkflowsReader(new Finder($this->resolveWorkflowCandidates($input)));
-        $this->localJobs = $this->workflowsReader->read();
+        // The candidate folders are resolved at run time (CLI options --project-dir/--workflows-dir, config,
+        // git root) and passed to read(): the reader itself is a plain injected collaborator.
+        $this->localJobs = $this->workflowsReader->read($this->resolveWorkflowCandidates($input));
 
         $this->githubClient->authenticate(tokenOrLogin: $repoToken, authMethod: AuthMethod::ACCESS_TOKEN);
         $repo = $this->githubClient->api('repo');
@@ -333,15 +332,16 @@ abstract class AbstractCommand extends Command
     /**
      * Builds the ordered list of candidate folders where the workflows may live.
      *
-     * Resolution order (first existing folder wins, handled by {@see Finder}):
+     * Resolution order (first existing folder wins, handled by the Reader/Finder):
      *   1. `--workflows-dir` (CLI)
      *   2. `GHMatrixConfig::getWorkflowsDir()` (config)
      *   3. `--project-dir` (CLI)                → `<project-dir>/.github/workflows`
      *   4. `GHMatrixConfig::getProjectDir()`    → `<projectDir>/.github/workflows`
      *   5. git root (`RepoReader::getRepoRoot()`, wrapped) → `<root>/.github/workflows`
-     *   6. the existing `__DIR__` fallbacks (`Finder::FROM_VENDOR`, `Finder::FROM_VENDOR_BIN_VENDOR`)
      *
-     * With nothing declared, the list is just the two `__DIR__` fallbacks: behaviour is identical to before.
+     * The package's own `__DIR__` fallbacks are appended LAST by the Finder itself, so callers never
+     * need to know about them. With nothing declared, this returns an empty list and the Finder falls
+     * back to those package locations: behaviour is identical to before.
      *
      * @return array<int, string>
      */
@@ -377,12 +377,8 @@ abstract class AbstractCommand extends Command
         try {
             $candidates[] = $this->workflowsDirFromProjectDir($this->repoReader->getRepoRoot());
         } catch (\Throwable) {
-            // git not available or not in a git repository — fall through to the __DIR__ fallbacks
+            // git not available or not in a git repository — the Finder falls back to the package locations.
         }
-
-        // Priority 6: the existing __DIR__ fallbacks (backward compatible)
-        $candidates[] = Finder::FROM_VENDOR;
-        $candidates[] = Finder::FROM_VENDOR_BIN_VENDOR;
 
         return $candidates;
     }

--- a/src/Console/Command/Params/Options/ProjectDirCommandOption.php
+++ b/src/Console/Command/Params/Options/ProjectDirCommandOption.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Aerendir GitHub Actions Matrix.
+ *
+ * Copyright (c) Adamo Aerendir Crespi <aerendir@serendipityhq.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options;
+
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * The project root that contains the `.github/workflows` folder.
+ *
+ * Resolved via config/inference (no interactive prompt), so only `getValueOrNull()` is needed.
+ */
+final class ProjectDirCommandOption
+{
+    public const string NAME     = 'project-dir';
+    public const string SHORTCUT = 'p';
+
+    public function getValueOrNull(InputInterface $input): ?string
+    {
+        $value = $input->getOption(self::NAME);
+
+        return is_string($value) ? $value : null;
+    }
+}

--- a/src/Console/Command/Params/Options/WorkflowsDirCommandOption.php
+++ b/src/Console/Command/Params/Options/WorkflowsDirCommandOption.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Aerendir GitHub Actions Matrix.
+ *
+ * Copyright (c) Adamo Aerendir Crespi <aerendir@serendipityhq.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options;
+
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * The folder that directly contains the workflow `*.yml` files.
+ *
+ * Escape hatch for non-standard layouts. Resolved via config/inference (no interactive prompt),
+ * so only `getValueOrNull()` is needed.
+ */
+final class WorkflowsDirCommandOption
+{
+    public const string NAME     = 'workflows-dir';
+    public const string SHORTCUT = 'w';
+
+    public function getValueOrNull(InputInterface $input): ?string
+    {
+        $value = $input->getOption(self::NAME);
+
+        return is_string($value) ? $value : null;
+    }
+}

--- a/src/Workflow/Finder.php
+++ b/src/Workflow/Finder.php
@@ -19,10 +19,10 @@ use Symfony\Component\Finder\SplFileInfo;
 class Finder
 {
     /** @var string When installed in the main `composer.json` */
-    private const string FROM_VENDOR = __DIR__ . '/../../.github/workflows';
+    public const string FROM_VENDOR = __DIR__ . '/../../.github/workflows';
 
     /** @var string When installed in `vendor-bin/[namespace]/vendor` by `bamarni/bin-composer-plugin´ */
-    private const string FROM_VENDOR_BIN_VENDOR = __DIR__ . '/../../../../../../../.github/workflows';
+    public const string FROM_VENDOR_BIN_VENDOR = __DIR__ . '/../../../../../../../.github/workflows';
 
     private readonly SymfonyFinder $finder;
 

--- a/src/Workflow/Finder.php
+++ b/src/Workflow/Finder.php
@@ -18,23 +18,39 @@ use Symfony\Component\Finder\SplFileInfo;
 
 class Finder
 {
+    // These are the package's own workflow locations, used as the LAST-resort fallbacks when no
+    // explicit folder is given (or none of the explicit ones exist). They are an internal detail of
+    // how the package is laid out on disk, so they are private: the CLI layer passes its candidate
+    // folders to getWorkflows() and never needs to reference these directly.
+
     /** @var string When installed in the main `composer.json` */
-    public const string FROM_VENDOR = __DIR__ . '/../../.github/workflows';
+    private const string FROM_VENDOR = __DIR__ . '/../../.github/workflows';
 
     /** @var string When installed in `vendor-bin/[namespace]/vendor` by `bamarni/bin-composer-plugin´ */
-    public const string FROM_VENDOR_BIN_VENDOR = __DIR__ . '/../../../../../../../.github/workflows';
-
-    private readonly SymfonyFinder $finder;
+    private const string FROM_VENDOR_BIN_VENDOR = __DIR__ . '/../../../../../../../.github/workflows';
 
     /**
-     * @param array<array-key, string> $possibleFolders
+     * @param array<array-key, string> $fallbackFolders The package-relative fallbacks, always tried
+     *                                                  LAST. Injectable so tests can exercise the
+     *                                                  "no folder found" path deterministically.
      */
-    public function __construct(array $possibleFolders = [self::FROM_VENDOR, self::FROM_VENDOR_BIN_VENDOR])
+    public function __construct(
+        private readonly array $fallbackFolders = [self::FROM_VENDOR, self::FROM_VENDOR_BIN_VENDOR],
+    ) {
+    }
+
+    /**
+     * @param array<array-key, string> $possibleFolders explicit candidate folders, tried first and in
+     *                                                  order; the package fallbacks are appended after
+     *
+     * @return \Iterator<string, SplFileInfo>
+     */
+    public function getWorkflows(array $possibleFolders = []): \Iterator
     {
-        $finder = new SymfonyFinder();
+        $candidates = [...array_values($possibleFolders), ...array_values($this->fallbackFolders)];
 
         $foundFolder = null;
-        foreach ($possibleFolders as $folder) {
+        foreach ($candidates as $folder) {
             if (false === file_exists($folder)) {
                 continue;
             }
@@ -48,14 +64,6 @@ class Finder
             throw new \RuntimeException('Impossible to locate the GitHub workflows folder');
         }
 
-        $this->finder = $finder->files()->name('*.yml')->in($foundFolder);
-    }
-
-    /**
-     * @return \Iterator<string, SplFileInfo>
-     */
-    public function getWorkflows(): \Iterator
-    {
-        return $this->finder->getIterator();
+        return (new SymfonyFinder())->files()->name('*.yml')->in($foundFolder)->getIterator();
     }
 }

--- a/src/Workflow/Reader.php
+++ b/src/Workflow/Reader.php
@@ -26,10 +26,14 @@ class Reader
     {
     }
 
-    public function read(): JobsCollection
+    /**
+     * @param array<array-key, string> $possibleFolders explicit folders to look into, in priority order;
+     *                                                  the Finder appends the package fallbacks after them
+     */
+    public function read(array $possibleFolders = []): JobsCollection
     {
         $localJobs = new JobsCollection();
-        foreach ($this->finder->getWorkflows() as $workflowFile) {
+        foreach ($this->finder->getWorkflows($possibleFolders) as $workflowFile) {
             $readCollection = $this->createFromYaml($workflowFile);
             $localJobs->mergeCollection($readCollection);
         }

--- a/tests/Config/GHMatrixConfigTest.php
+++ b/tests/Config/GHMatrixConfigTest.php
@@ -118,6 +118,56 @@ class GHMatrixConfigTest extends TestCase
         $this->assertNull($config->getTokenFile());
     }
 
+    public function testGetProjectDirReturnsNullInitially(): void
+    {
+        $config = new GHMatrixConfig();
+        $this->assertNull($config->getProjectDir());
+    }
+
+    public function testSetProjectDirAndGetProjectDir(): void
+    {
+        $config     = new GHMatrixConfig();
+        $projectDir = '/srv/app';
+
+        $config->setProjectDir($projectDir);
+
+        $this->assertSame($projectDir, $config->getProjectDir());
+    }
+
+    public function testSetProjectDirWithNull(): void
+    {
+        $config = new GHMatrixConfig();
+        $config->setProjectDir('/srv/app');
+        $config->setProjectDir(null);
+
+        $this->assertNull($config->getProjectDir());
+    }
+
+    public function testGetWorkflowsDirReturnsNullInitially(): void
+    {
+        $config = new GHMatrixConfig();
+        $this->assertNull($config->getWorkflowsDir());
+    }
+
+    public function testSetWorkflowsDirAndGetWorkflowsDir(): void
+    {
+        $config       = new GHMatrixConfig();
+        $workflowsDir = '/srv/app/.github/workflows';
+
+        $config->setWorkflowsDir($workflowsDir);
+
+        $this->assertSame($workflowsDir, $config->getWorkflowsDir());
+    }
+
+    public function testSetWorkflowsDirWithNull(): void
+    {
+        $config = new GHMatrixConfig();
+        $config->setWorkflowsDir('/srv/app/.github/workflows');
+        $config->setWorkflowsDir(null);
+
+        $this->assertNull($config->getWorkflowsDir());
+    }
+
     public function testMarkOptionalCombinationAddsValidCombination(): void
     {
         $config       = new GHMatrixConfig();

--- a/tests/Console/Command/ConfigPriorityTest.php
+++ b/tests/Console/Command/ConfigPriorityTest.php
@@ -592,6 +592,138 @@ class ConfigPriorityTest extends CommandTestCase
         }
     }
 
+    public function testProjectDirFromConfigDrivesWorkflowDiscovery(): void
+    {
+        $testUsername    = 'test-user';
+        $testRepo        = 'test-repo';
+        $testGitHubToken = 'ghp_1234567890abcdef1234567890abcdef1234';
+
+        // A temp project that contains .github/workflows/*.yml
+        $projectDir   = sys_get_temp_dir() . '/gh-matrix-project-' . uniqid();
+        $workflowsDir = $projectDir . '/.github/workflows';
+        mkdir($workflowsDir, 0777, true);
+        $workflowFile = $workflowsDir . '/ci.yml';
+        file_put_contents($workflowFile, <<<YAML
+            name: PHP CS
+            on: [push]
+            jobs:
+              phpcs:
+                strategy:
+                  fail-fast: false
+                  matrix:
+                    php: [ '8.3', '8.4' ]
+                steps:
+                  - name: Checkout
+                    uses: actions/checkout@v3
+            YAML);
+
+        try {
+            $config = new GHMatrixConfig();
+            $config->setUser($testUsername);
+            $config->setBranch('master');
+            $config->setProjectDir($projectDir);
+
+            $mockRepoReader = $this->createMock(RepoReader::class);
+            $mockRepoReader->method('getRepoName')->willReturn($testRepo);
+            $mockRepoReader->method('filterProtectedBranches')->willReturn(['master']);
+            // Simulate "no git": the workflows must be discovered via setProjectDir(), not the git root.
+            $mockRepoReader->method('getRepoRoot')->willThrowException(new \RuntimeException('not a git repository'));
+
+            $mockGitHubClient = $this->createMockGitHubClient();
+
+            // NOTE: no workflowsReader injected -> the lazy Finder must discover the workflows via setProjectDir().
+            $command = new SyncCommand(
+                config: $config,
+                repoReader: $mockRepoReader,
+                githubClient: $mockGitHubClient
+            );
+
+            $application = new Application();
+            $application->addCommand($command);
+
+            $commandTester = new CommandTester($command);
+            $commandTester->execute([
+                '--' . GitHubTokenCommandOption::NAME => $testGitHubToken,
+            ]);
+
+            // Succeeds only if the lazy Finder located the workflows under <projectDir>/.github/workflows.
+            $this->assertEquals(0, $commandTester->getStatusCode());
+        } finally {
+            // Cleanup (innermost first)
+            if (file_exists($workflowFile)) {
+                unlink($workflowFile);
+            }
+            if (is_dir($workflowsDir)) {
+                rmdir($workflowsDir);
+            }
+            if (is_dir($projectDir . '/.github')) {
+                rmdir($projectDir . '/.github');
+            }
+            if (is_dir($projectDir)) {
+                rmdir($projectDir);
+            }
+        }
+    }
+
+    public function testTokenBasePrefersProjectDirOverGitRoot(): void
+    {
+        $testUsername   = 'test-user';
+        $testRepo       = 'test-repo';
+        $tokenFileToken = 'ghp_1234567890123456789012345678901234ab';
+
+        // projectDir CONTAINS the token file; the git root deliberately does NOT.
+        $projectDir = sys_get_temp_dir() . '/gh-matrix-proj-' . uniqid();
+        $gitRoot    = sys_get_temp_dir() . '/gh-matrix-git-' . uniqid();
+        mkdir($projectDir, 0777, true);
+        mkdir($gitRoot, 0777, true);
+        $tokenFile = $projectDir . '/gh_token';
+        file_put_contents($tokenFile, $tokenFileToken);
+
+        try {
+            $config = new GHMatrixConfig();
+            $config->setUser($testUsername);
+            $config->setBranch('master');
+            $config->setTokenFile('gh_token');
+            $config->setProjectDir($projectDir);
+
+            $mockRepoReader = $this->createMock(RepoReader::class);
+            $mockRepoReader->method('getRepoName')->willReturn($testRepo);
+            $mockRepoReader->method('filterProtectedBranches')->willReturn(['master']);
+            // Git root is available but lacks the token file: if it were preferred, resolution would fail.
+            $mockRepoReader->method('getRepoRoot')->willReturn($gitRoot);
+
+            $mockWorkflowsReader = $this->createMockWorkflowsReader();
+            $mockGitHubClient    = $this->createMockGitHubClient();
+
+            $command = new SyncCommand(
+                config: $config,
+                repoReader: $mockRepoReader,
+                workflowsReader: $mockWorkflowsReader,
+                githubClient: $mockGitHubClient
+            );
+
+            $application = new Application();
+            $application->addCommand($command);
+
+            $commandTester = new CommandTester($command);
+            $commandTester->execute([]);
+
+            // Succeeds only if the token file was resolved against projectDir (not the git root).
+            $this->assertEquals(0, $commandTester->getStatusCode());
+        } finally {
+            // Cleanup
+            if (file_exists($tokenFile)) {
+                unlink($tokenFile);
+            }
+            if (is_dir($projectDir)) {
+                rmdir($projectDir);
+            }
+            if (is_dir($gitRoot)) {
+                rmdir($gitRoot);
+            }
+        }
+    }
+
     public function testConfigBranchValidAndInProtectedBranches(): void
     {
         $configBranch    = 'develop';

--- a/tests/Console/Command/ConfigPriorityTest.php
+++ b/tests/Console/Command/ConfigPriorityTest.php
@@ -1091,4 +1091,149 @@ class ConfigPriorityTest extends CommandTestCase
             }
         }
     }
+
+    public function testWorkflowsDirFromCliDrivesWorkflowDiscovery(): void
+    {
+        [$projectDir, $workflowsDir] = $this->createTempProjectWithWorkflow();
+
+        try {
+            $config = new GHMatrixConfig();
+            $config->setUser('test-user');
+            $config->setBranch('master');
+
+            $command = new SyncCommand(
+                config: $config,
+                repoReader: $this->createGitlessRepoReader('test-repo'),
+                githubClient: $this->createMockGitHubClient()
+            );
+
+            $application = new Application();
+            $application->addCommand($command);
+
+            $commandTester = new CommandTester($command);
+            $commandTester->execute([
+                '--' . GitHubTokenCommandOption::NAME => 'ghp_1234567890abcdef1234567890abcdef1234',
+                '--workflows-dir'                     => $workflowsDir,
+            ]);
+
+            $this->assertEquals(0, $commandTester->getStatusCode());
+        } finally {
+            $this->removeTempProject($projectDir);
+        }
+    }
+
+    public function testWorkflowsDirFromConfigDrivesWorkflowDiscovery(): void
+    {
+        [$projectDir, $workflowsDir] = $this->createTempProjectWithWorkflow();
+
+        try {
+            $config = new GHMatrixConfig();
+            $config->setUser('test-user');
+            $config->setBranch('master');
+            $config->setWorkflowsDir($workflowsDir);
+
+            $command = new SyncCommand(
+                config: $config,
+                repoReader: $this->createGitlessRepoReader('test-repo'),
+                githubClient: $this->createMockGitHubClient()
+            );
+
+            $application = new Application();
+            $application->addCommand($command);
+
+            $commandTester = new CommandTester($command);
+            $commandTester->execute([
+                '--' . GitHubTokenCommandOption::NAME => 'ghp_1234567890abcdef1234567890abcdef1234',
+            ]);
+
+            $this->assertEquals(0, $commandTester->getStatusCode());
+        } finally {
+            $this->removeTempProject($projectDir);
+        }
+    }
+
+    public function testProjectDirFromCliDrivesWorkflowDiscovery(): void
+    {
+        [$projectDir] = $this->createTempProjectWithWorkflow();
+
+        try {
+            $config = new GHMatrixConfig();
+            $config->setUser('test-user');
+            $config->setBranch('master');
+
+            $command = new SyncCommand(
+                config: $config,
+                repoReader: $this->createGitlessRepoReader('test-repo'),
+                githubClient: $this->createMockGitHubClient()
+            );
+
+            $application = new Application();
+            $application->addCommand($command);
+
+            $commandTester = new CommandTester($command);
+            $commandTester->execute([
+                '--' . GitHubTokenCommandOption::NAME => 'ghp_1234567890abcdef1234567890abcdef1234',
+                '--project-dir'                       => $projectDir,
+            ]);
+
+            $this->assertEquals(0, $commandTester->getStatusCode());
+        } finally {
+            $this->removeTempProject($projectDir);
+        }
+    }
+
+    /**
+     * Creates a temp project containing `.github/workflows/ci.yml`.
+     *
+     * @return array{0: string, 1: string} [projectDir, workflowsDir]
+     */
+    private function createTempProjectWithWorkflow(): array
+    {
+        $projectDir   = sys_get_temp_dir() . '/gh-matrix-wf-' . uniqid();
+        $workflowsDir = $projectDir . '/.github/workflows';
+        mkdir($workflowsDir, 0777, true);
+        file_put_contents($workflowsDir . '/ci.yml', <<<YAML
+            name: PHP CS
+            on: [push]
+            jobs:
+              phpcs:
+                strategy:
+                  fail-fast: false
+                  matrix:
+                    php: [ '8.3', '8.4' ]
+                steps:
+                  - name: Checkout
+                    uses: actions/checkout@v3
+            YAML);
+
+        return [$projectDir, $workflowsDir];
+    }
+
+    private function removeTempProject(string $projectDir): void
+    {
+        $workflowFile = $projectDir . '/.github/workflows/ci.yml';
+        if (file_exists($workflowFile)) {
+            unlink($workflowFile);
+        }
+
+        foreach ([$projectDir . '/.github/workflows', $projectDir . '/.github', $projectDir] as $dir) {
+            if (is_dir($dir)) {
+                rmdir($dir);
+            }
+        }
+    }
+
+    /**
+     * A RepoReader mock that resolves the repo name and protected branches but reports "no git"
+     * (so the workflows location must be resolved declaratively, not from the git root).
+     */
+    private function createGitlessRepoReader(string $repoName): RepoReader
+    {
+        $mockRepoReader = $this->createMock(RepoReader::class);
+        $mockRepoReader->method('getRepoName')->willReturn($repoName);
+        $mockRepoReader->method('filterProtectedBranches')->willReturn(['master']);
+        $mockRepoReader->method('getRepoRoot')->willThrowException(new \RuntimeException('not a git repository'));
+
+        return $mockRepoReader;
+    }
 }

--- a/tests/Console/Command/Params/Options/ProjectDirCommandOptionTest.php
+++ b/tests/Console/Command/Params/Options/ProjectDirCommandOptionTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Aerendir GitHub Actions Matrix.
+ *
+ * Copyright (c) Adamo Aerendir Crespi <aerendir@serendipityhq.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Aerendir\Bin\GitHubActionsMatrix\Tests\Console\Command\Params\Options;
+
+use Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options\ProjectDirCommandOption;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class ProjectDirCommandOptionTest extends TestCase
+{
+    public const string PROJECT_DIR_START = '<<<PROJECT_DIR ';
+    public const string PROJECT_DIR_END   = '>>>';
+
+    private ProjectDirCommandOption $projectDirCommandOption;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->projectDirCommandOption = new ProjectDirCommandOption();
+    }
+
+    public function testGetValueOrNullWithValueProvidedReturnsTheProvidedValue(): void
+    {
+        $testProjectDir = '/srv/app';
+        $expectedOutput = sprintf('%s%s%s', self::PROJECT_DIR_START, $testProjectDir, self::PROJECT_DIR_END);
+
+        $command       = $this->createCommandForGetValueOrNull();
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([
+            '--' . $this->projectDirCommandOption::NAME => $testProjectDir,
+        ]);
+
+        $this->assertStringContainsString($expectedOutput, $commandTester->getDisplay());
+    }
+
+    public function testGetValueOrNullWithoutValueProvidedReturnsNull(): void
+    {
+        $expectedOutput = sprintf('%s%s%s', self::PROJECT_DIR_START, '', self::PROJECT_DIR_END);
+
+        $command       = $this->createCommandForGetValueOrNull();
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([]);
+
+        $this->assertStringContainsString($expectedOutput, $commandTester->getDisplay());
+    }
+
+    private function createCommandForGetValueOrNull(): Command
+    {
+        return new class extends Command {
+            private readonly ProjectDirCommandOption $projectDirCommandOption;
+
+            public function __construct()
+            {
+                parent::__construct('test-get-option-project-dir-or-null');
+                $this->projectDirCommandOption = new ProjectDirCommandOption();
+            }
+
+            #[\Override]
+            protected function configure(): void
+            {
+                $this->addOption(
+                    ProjectDirCommandOption::NAME,
+                    ProjectDirCommandOption::SHORTCUT,
+                    InputOption::VALUE_OPTIONAL,
+                    'The project root that contains the ".github/workflows" folder.',
+                );
+            }
+
+            #[\Override]
+            protected function execute(InputInterface $input, OutputInterface $output): int
+            {
+                $projectDir = $this->projectDirCommandOption->getValueOrNull($input) ?? '';
+
+                $output->writeln(sprintf('%s%s%s', ProjectDirCommandOptionTest::PROJECT_DIR_START, $projectDir, ProjectDirCommandOptionTest::PROJECT_DIR_END));
+
+                return Command::SUCCESS;
+            }
+        };
+    }
+}

--- a/tests/Console/Command/Params/Options/WorkflowsDirCommandOptionTest.php
+++ b/tests/Console/Command/Params/Options/WorkflowsDirCommandOptionTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Aerendir GitHub Actions Matrix.
+ *
+ * Copyright (c) Adamo Aerendir Crespi <aerendir@serendipityhq.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Aerendir\Bin\GitHubActionsMatrix\Tests\Console\Command\Params\Options;
+
+use Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options\WorkflowsDirCommandOption;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class WorkflowsDirCommandOptionTest extends TestCase
+{
+    public const string WORKFLOWS_DIR_START = '<<<WORKFLOWS_DIR ';
+    public const string WORKFLOWS_DIR_END   = '>>>';
+
+    private WorkflowsDirCommandOption $workflowsDirCommandOption;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->workflowsDirCommandOption = new WorkflowsDirCommandOption();
+    }
+
+    public function testGetValueOrNullWithValueProvidedReturnsTheProvidedValue(): void
+    {
+        $testWorkflowsDir = '/srv/app/.github/workflows';
+        $expectedOutput   = sprintf('%s%s%s', self::WORKFLOWS_DIR_START, $testWorkflowsDir, self::WORKFLOWS_DIR_END);
+
+        $command       = $this->createCommandForGetValueOrNull();
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([
+            '--' . $this->workflowsDirCommandOption::NAME => $testWorkflowsDir,
+        ]);
+
+        $this->assertStringContainsString($expectedOutput, $commandTester->getDisplay());
+    }
+
+    public function testGetValueOrNullWithoutValueProvidedReturnsNull(): void
+    {
+        $expectedOutput = sprintf('%s%s%s', self::WORKFLOWS_DIR_START, '', self::WORKFLOWS_DIR_END);
+
+        $command       = $this->createCommandForGetValueOrNull();
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([]);
+
+        $this->assertStringContainsString($expectedOutput, $commandTester->getDisplay());
+    }
+
+    private function createCommandForGetValueOrNull(): Command
+    {
+        return new class extends Command {
+            private readonly WorkflowsDirCommandOption $workflowsDirCommandOption;
+
+            public function __construct()
+            {
+                parent::__construct('test-get-option-workflows-dir-or-null');
+                $this->workflowsDirCommandOption = new WorkflowsDirCommandOption();
+            }
+
+            #[\Override]
+            protected function configure(): void
+            {
+                $this->addOption(
+                    WorkflowsDirCommandOption::NAME,
+                    WorkflowsDirCommandOption::SHORTCUT,
+                    InputOption::VALUE_OPTIONAL,
+                    'The folder that directly contains the workflow "*.yml" files.',
+                );
+            }
+
+            #[\Override]
+            protected function execute(InputInterface $input, OutputInterface $output): int
+            {
+                $workflowsDir = $this->workflowsDirCommandOption->getValueOrNull($input) ?? '';
+
+                $output->writeln(sprintf('%s%s%s', WorkflowsDirCommandOptionTest::WORKFLOWS_DIR_START, $workflowsDir, WorkflowsDirCommandOptionTest::WORKFLOWS_DIR_END));
+
+                return Command::SUCCESS;
+            }
+        };
+    }
+}

--- a/tests/Workflow/FinderTest.php
+++ b/tests/Workflow/FinderTest.php
@@ -23,12 +23,13 @@ use function Safe\unlink;
 
 class FinderTest extends TestCase
 {
-    public function testConstructorThrowsExceptionWhenNoFolderExists(): void
+    public function testGetWorkflowsThrowsExceptionWhenNoFolderExists(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Impossible to locate the GitHub workflows folder');
 
-        new Finder([__DIR__ . '/non-existing-folder']);
+        // No fallbacks injected, so the only candidate is the (missing) explicit folder.
+        (new Finder(fallbackFolders: []))->getWorkflows([__DIR__ . '/non-existing-folder']);
     }
 
     public function testGetWorkflowsReturnsEmptyIteratorIfNoWorkflowsExist(): void
@@ -37,8 +38,7 @@ class FinderTest extends TestCase
         mkdir($tempDir);
 
         try {
-            $finder    = new Finder([$tempDir]);
-            $workflows = $finder->getWorkflows();
+            $workflows = (new Finder(fallbackFolders: []))->getWorkflows([$tempDir]);
 
             $this->assertCount(0, iterator_to_array($workflows));
         } finally {
@@ -46,7 +46,7 @@ class FinderTest extends TestCase
         }
     }
 
-    public function testConstructorPicksTheFirstExistingFolderFromTheCandidates(): void
+    public function testGetWorkflowsPicksTheFirstExistingFolderFromTheCandidates(): void
     {
         $missingDir  = sys_get_temp_dir() . '/finder-missing-' . uniqid();
         $existingDir = sys_get_temp_dir() . '/finder-existing-' . uniqid();
@@ -60,8 +60,7 @@ class FinderTest extends TestCase
 
         try {
             // Order: missing (skipped) -> existing (picked) -> later (never reached).
-            $finder    = new Finder([$missingDir, $existingDir, $laterDir]);
-            $workflows = iterator_to_array($finder->getWorkflows());
+            $workflows = iterator_to_array((new Finder(fallbackFolders: []))->getWorkflows([$missingDir, $existingDir, $laterDir]));
 
             $this->assertCount(1, $workflows);
             $this->assertEquals('winner.yml', $workflows[$existingDir . '/winner.yml']->getFilename());
@@ -73,11 +72,23 @@ class FinderTest extends TestCase
         }
     }
 
-    public function testPublicDirConstantsAreExposedForComposition(): void
+    public function testGetWorkflowsFallsBackToFallbackFoldersWhenNoExplicitFolderMatches(): void
     {
-        // The CLI layer composes these as the tail of the candidate list, so they must stay public.
-        $this->assertStringEndsWith('.github/workflows', Finder::FROM_VENDOR);
-        $this->assertStringEndsWith('.github/workflows', Finder::FROM_VENDOR_BIN_VENDOR);
+        $missingDir  = sys_get_temp_dir() . '/finder-missing-' . uniqid();
+        $fallbackDir = sys_get_temp_dir() . '/finder-fallback-' . uniqid();
+        mkdir($fallbackDir);
+        file_put_contents($fallbackDir . '/from-fallback.yml', 'name: Fallback');
+
+        try {
+            // The explicit folder does not exist, so the injected fallback (tried last) must win.
+            $workflows = iterator_to_array((new Finder(fallbackFolders: [$fallbackDir]))->getWorkflows([$missingDir]));
+
+            $this->assertCount(1, $workflows);
+            $this->assertEquals('from-fallback.yml', $workflows[$fallbackDir . '/from-fallback.yml']->getFilename());
+        } finally {
+            unlink($fallbackDir . '/from-fallback.yml');
+            rmdir($fallbackDir);
+        }
     }
 
     public function testGetWorkflowsReturnsIteratorWithWorkflowFiles(): void
@@ -89,8 +100,7 @@ class FinderTest extends TestCase
         file_put_contents($workflowFile, 'name: Test Workflow');
 
         try {
-            $finder    = new Finder([$tempDir]);
-            $workflows = iterator_to_array($finder->getWorkflows());
+            $workflows = iterator_to_array((new Finder(fallbackFolders: []))->getWorkflows([$tempDir]));
 
             $this->assertCount(1, $workflows);
             $this->assertEquals('test-workflow.yml', $workflows[$workflowFile]->getFilename());

--- a/tests/Workflow/FinderTest.php
+++ b/tests/Workflow/FinderTest.php
@@ -46,6 +46,40 @@ class FinderTest extends TestCase
         }
     }
 
+    public function testConstructorPicksTheFirstExistingFolderFromTheCandidates(): void
+    {
+        $missingDir  = sys_get_temp_dir() . '/finder-missing-' . uniqid();
+        $existingDir = sys_get_temp_dir() . '/finder-existing-' . uniqid();
+        $laterDir    = sys_get_temp_dir() . '/finder-later-' . uniqid();
+        mkdir($existingDir);
+        mkdir($laterDir);
+
+        // The workflow lives in the FIRST existing folder; the one in $laterDir must be ignored.
+        file_put_contents($existingDir . '/winner.yml', 'name: Winner');
+        file_put_contents($laterDir . '/loser.yml', 'name: Loser');
+
+        try {
+            // Order: missing (skipped) -> existing (picked) -> later (never reached).
+            $finder    = new Finder([$missingDir, $existingDir, $laterDir]);
+            $workflows = iterator_to_array($finder->getWorkflows());
+
+            $this->assertCount(1, $workflows);
+            $this->assertEquals('winner.yml', $workflows[$existingDir . '/winner.yml']->getFilename());
+        } finally {
+            unlink($existingDir . '/winner.yml');
+            unlink($laterDir . '/loser.yml');
+            rmdir($existingDir);
+            rmdir($laterDir);
+        }
+    }
+
+    public function testPublicDirConstantsAreExposedForComposition(): void
+    {
+        // The CLI layer composes these as the tail of the candidate list, so they must stay public.
+        $this->assertStringEndsWith('.github/workflows', Finder::FROM_VENDOR);
+        $this->assertStringEndsWith('.github/workflows', Finder::FROM_VENDOR_BIN_VENDOR);
+    }
+
     public function testGetWorkflowsReturnsIteratorWithWorkflowFiles(): void
     {
         $tempDir = sys_get_temp_dir() . '/workflow-test-folder';


### PR DESCRIPTION
Part of #35. Closes #38.

The workflows folder was located only via two hardcoded __DIR__ paths in
Workflow\Finder, which break in a monorepo (workflows at the root, tool in a
sub-project) and under a type: path symlinked install. Add explicit
configuration and CLI while preserving every existing inference fallback.

Resolution order (first existing folder wins):
  1. --workflows-dir (CLI)
  2. GHMatrixConfig::setWorkflowsDir() (config)
  3. --project-dir (CLI)              -> <project-dir>/.github/workflows
  4. GHMatrixConfig::setProjectDir()  -> <projectDir>/.github/workflows
  5. git root                         -> <root>/.github/workflows
  6. the existing __DIR__ fallbacks

The workflows reader is now built lazily in init() so CLI options apply;
injected readers (test mocks) are kept. resolveTokenBaseDir() now prefers the
configured projectDir, completing the token-base chain from #37. With nothing
declared, behaviour is identical to before.

New ProjectDirCommandOption / WorkflowsDirCommandOption (resolve via
config/inference, no prompt). Finder::FROM_VENDOR(_BIN_VENDOR) are now public
so the command layer can compose them at the tail of the candidate list.

Docs (README + gh-actions-matrix.dist.php) updated. Tests cover config
get/set, Finder first-existing-wins, both option classes, projectDir-driven
discovery via the lazy Finder, and projectDir precedence for the token base.