### PR TITLE
fix: discover workflow files with the ".yaml" extension too

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ vendor/bin/github-actions-matrix compare [options]
 - `-b, --branch=BRANCH` - The branch to compare
 - `-t, --token=TOKEN` - Your GitHub access token
 - `-p, --project-dir=PROJECT-DIR` - The project root that contains the `.github/workflows` folder
-- `-w, --workflows-dir=WORKFLOWS-DIR` - The folder that directly contains the workflow `*.yml` files (non-standard layouts)
+- `-w, --workflows-dir=WORKFLOWS-DIR` - The folder that directly contains the workflow `*.yml`/`*.yaml` files (non-standard layouts)
 
 **Example:**
 ```bash
@@ -109,7 +109,7 @@ vendor/bin/github-actions-matrix sync [options]
 - `-b, --branch=BRANCH` - The branch to sync
 - `-t, --token=TOKEN` - Your GitHub access token
 - `-p, --project-dir=PROJECT-DIR` - The project root that contains the `.github/workflows` folder
-- `-w, --workflows-dir=WORKFLOWS-DIR` - The folder that directly contains the workflow `*.yml` files (non-standard layouts)
+- `-w, --workflows-dir=WORKFLOWS-DIR` - The folder that directly contains the workflow `*.yml`/`*.yaml` files (non-standard layouts)
 
 **Example:**
 ```bash
@@ -159,7 +159,7 @@ Every value can be provided on the command line or declared in the configuration
 | `setBranch(string)` | `-b, --branch` | The protected branch to compare/sync. |
 | `setTokenFile(string)` | _(see `-t, --token`)_ | Name/path of a file containing the GitHub token, resolved against `projectDir → git root → cwd`. The CLI `-t, --token` instead passes the token value directly. |
 | `setProjectDir(string)` | `-p, --project-dir` | Project root that contains `.github/workflows`; also the preferred base directory for the token file. |
-| `setWorkflowsDir(string)` | `-w, --workflows-dir` | Folder that directly contains the workflow `*.yml` files. Escape hatch for non-standard layouts. |
+| `setWorkflowsDir(string)` | `-w, --workflows-dir` | Folder that directly contains the workflow `*.yml`/`*.yaml` files. Escape hatch for non-standard layouts. |
 
 > The GitHub token must have **repo-admin** scope. Provide it via `setTokenFile()` (pointing at a gitignored file) or `-t, --token` — never commit it.
 

--- a/src/Config/GHMatrixConfig.php
+++ b/src/Config/GHMatrixConfig.php
@@ -86,7 +86,7 @@ final class GHMatrixConfig
     }
 
     /**
-     * The folder that directly contains the workflow `*.yml` files.
+     * The folder that directly contains the workflow `*.yml`/`*.yaml` files.
      *
      * Escape hatch for non-standard layouts where the workflows do not live under `<projectDir>/.github/workflows`.
      */

--- a/src/Console/Command/AbstractCommand.php
+++ b/src/Console/Command/AbstractCommand.php
@@ -96,7 +96,7 @@ abstract class AbstractCommand extends Command
         $this->addOption(RepoBranchCommandOption::NAME, RepoBranchCommandOption::SHORTCUT, InputOption::VALUE_REQUIRED, 'The branch for which the matrix has to be synchronized.');
         $this->addOption(RepoNameCommandOption::NAME, RepoNameCommandOption::SHORTCUT, InputOption::VALUE_REQUIRED, 'The name of the GitHub repository.');
         $this->addOption(ProjectDirCommandOption::NAME, ProjectDirCommandOption::SHORTCUT, InputOption::VALUE_REQUIRED, 'The project root that contains the ".github/workflows" folder.');
-        $this->addOption(WorkflowsDirCommandOption::NAME, WorkflowsDirCommandOption::SHORTCUT, InputOption::VALUE_REQUIRED, 'The folder that directly contains the workflow "*.yml" files (non-standard layouts).');
+        $this->addOption(WorkflowsDirCommandOption::NAME, WorkflowsDirCommandOption::SHORTCUT, InputOption::VALUE_REQUIRED, 'The folder that directly contains the workflow "*.yml"/"*.yaml" files (non-standard layouts).');
     }
 
     protected function init(InputInterface $input, OutputInterface $output): void

--- a/src/Workflow/Finder.php
+++ b/src/Workflow/Finder.php
@@ -64,6 +64,6 @@ class Finder
             throw new \RuntimeException('Impossible to locate the GitHub workflows folder');
         }
 
-        return (new SymfonyFinder())->files()->name('*.yml')->in($foundFolder)->getIterator();
+        return (new SymfonyFinder())->files()->name(['*.yml', '*.yaml'])->in($foundFolder)->getIterator();
     }
 }

--- a/tests/Workflow/FinderTest.php
+++ b/tests/Workflow/FinderTest.php
@@ -91,6 +91,28 @@ class FinderTest extends TestCase
         }
     }
 
+    public function testGetWorkflowsDiscoversBothYmlAndYamlExtensions(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/finder-mixed-ext-' . uniqid();
+        mkdir($tempDir);
+
+        // GitHub Actions recognises both extensions: the Finder must discover them both.
+        file_put_contents($tempDir . '/with-yml.yml', 'name: With yml');
+        file_put_contents($tempDir . '/with-yaml.yaml', 'name: With yaml');
+
+        try {
+            $workflows = iterator_to_array((new Finder(fallbackFolders: []))->getWorkflows([$tempDir]));
+
+            $this->assertCount(2, $workflows);
+            $this->assertArrayHasKey($tempDir . '/with-yml.yml', $workflows);
+            $this->assertArrayHasKey($tempDir . '/with-yaml.yaml', $workflows);
+        } finally {
+            unlink($tempDir . '/with-yml.yml');
+            unlink($tempDir . '/with-yaml.yaml');
+            rmdir($tempDir);
+        }
+    }
+
     public function testGetWorkflowsReturnsIteratorWithWorkflowFiles(): void
     {
         $tempDir = sys_get_temp_dir() . '/workflow-test-folder';


### PR DESCRIPTION
## What

`Finder::getWorkflows()` now discovers both `*.yml` **and** `*.yaml` workflow files (`->name(['*.yml', '*.yaml'])`).

## Why

GitHub Actions recognises both extensions. The Finder matched only `*.yml`, so a `.yaml` workflow was **silently ignored** → its jobs never entered the desired set → `sync` would **remove** those contexts from branch protection. Silent and destructive.

## Changes

- `Finder`: match `*.yml` and `*.yaml`.
- Test: a folder containing both `a.yml` and `b.yaml` is fully discovered (count 2).
- Docs: README (CLI option ×2 + config table), the `--workflows-dir` option description, and the `setWorkflowsDir()` docblock now mention `*.yml`/`*.yaml`.

## Notes

Standalone, atomic PR off `master`. Driver context: TrustBack.Me `#5382`.

Closes #52
