### PR TITLE
fix: accept fine-grained PATs (github_pat_) when validating the token

### DIFF
--- a/.baseline-phpstan.neon
+++ b/.baseline-phpstan.neon
@@ -103,36 +103,6 @@ parameters:
 			path: src/Console/Command/CompareCommand.php
 
 		-
-			message: '#^Anonymous function should return string but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Console/Command/Params/Options/GitHubTokenCommandOption.php
-
-		-
-			message: '#^Method Aerendir\\Bin\\GitHubActionsMatrix\\Console\\Command\\Params\\Options\\GitHubTokenCommandOption\:\:askForValue\(\) should return string but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Console/Command/Params/Options/GitHubTokenCommandOption.php
-
-		-
-			message: '#^Method Aerendir\\Bin\\GitHubActionsMatrix\\Console\\Command\\Params\\Options\\GitHubTokenCommandOption\:\:getValueOrAsk\(\) should return string but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Console/Command/Params/Options/GitHubTokenCommandOption.php
-
-		-
-			message: '#^Method Aerendir\\Bin\\GitHubActionsMatrix\\Console\\Command\\Params\\Options\\GitHubTokenCommandOption\:\:getValueOrNull\(\) should return string\|null but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Console/Command/Params/Options/GitHubTokenCommandOption.php
-
-		-
-			message: '#^Parameter \#2 \$subject of function Safe\\preg_match expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Console/Command/Params/Options/GitHubTokenCommandOption.php
-
-		-
 			message: '#^Method Aerendir\\Bin\\GitHubActionsMatrix\\Console\\Command\\Params\\Options\\GitHubUsernameCommandOption\:\:askForValue\(\) should return string but returns mixed\.$#'
 			identifier: return.type
 			count: 1

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Every value can be provided on the command line or declared in the configuration
 | `setProjectDir(string)` | `-p, --project-dir` | Project root that contains `.github/workflows`; also the preferred base directory for the token file. |
 | `setWorkflowsDir(string)` | `-w, --workflows-dir` | Folder that directly contains the workflow `*.yml` files. Escape hatch for non-standard layouts. |
 
-> The GitHub token must have **repo-admin** scope. Provide it via `setTokenFile()` (pointing at a gitignored file) or `-t, --token` — never commit it.
+> The GitHub token must have **repo-admin** scope. Classic (`ghp_…`), fine-grained (`github_pat_…`) and app/installation (`ghs_…`) tokens are accepted. Provide it via `setTokenFile()` (pointing at a gitignored file) or `-t, --token` — never commit it.
 
 #### Priority Order
 

--- a/src/Console/Command/AbstractCommand.php
+++ b/src/Console/Command/AbstractCommand.php
@@ -37,7 +37,6 @@ use Symfony\Component\HttpClient\HttplugClient;
 
 use function Safe\file_get_contents;
 use function Safe\getcwd;
-use function Safe\preg_match;
 use function Safe\realpath;
 
 abstract class AbstractCommand extends Command
@@ -318,9 +317,10 @@ abstract class AbstractCommand extends Command
             // Trim whitespace and newlines
             $token = trim($content);
 
-            // Validate the token format using the same validation as the option.
-            // An invalid token read from the file falls back to prompting, consistent with GitHubTokenCommandOption.
-            if (0 === preg_match('/^ghp_[A-Za-z0-9]{36}$/', $token)) {
+            // Validate the token format using the very same definition as the option (single source of
+            // truth). An invalid token read from the file falls back to prompting, consistent with
+            // GitHubTokenCommandOption.
+            if (false === $this->gitHubTokenCommandOption->isValidFormat($token)) {
                 return null;
             }
 

--- a/src/Console/Command/Params/Options/GitHubTokenCommandOption.php
+++ b/src/Console/Command/Params/Options/GitHubTokenCommandOption.php
@@ -29,35 +29,52 @@ class GitHubTokenCommandOption
     final public const string SHORTCUT = 't';
     private const int MAX_ATTEMPTS     = 2;
 
+    /**
+     * The accepted GitHub token formats, as the single source of truth shared by every token source
+     * (CLI option, token file, environment variable), so the pattern is never duplicated:
+     *  - classic personal access token:      `ghp_` + 36 alphanumerics
+     *  - fine-grained personal access token: `github_pat_` + 82 chars (alphanumerics and underscores)
+     *  - app / installation access token:    `ghs_` + 36 alphanumerics.
+     */
+    private const string FORMAT_PATTERN = '/^(?:ghp_[A-Za-z0-9]{36}|github_pat_\w{82}|ghs_[A-Za-z0-9]{36})$/';
+
     public function getValueOrAsk(InputInterface $input, OutputInterface $output, QuestionHelper $questionHelper, ?int $maxAttempts = null): string
     {
-        $validationCallback = $this->getValidationCallback();
-        $token              = $this->getValueOrNull($input);
+        $token = $this->getValueOrNull($input);
 
         return null === $token
             ? $this->askForValue($input, $output, $questionHelper, $maxAttempts)
-            : $validationCallback($token);
+            : $token;
     }
 
     public function getValueOrNull(InputInterface $input): ?string
     {
-        $validationCallback = $this->getValidationCallback();
-        $value              = $input->getOption(self::NAME);
+        $value = $input->getOption(self::NAME);
 
         if (null === $value) {
             return null;
         }
 
-        return $validationCallback($value);
+        return $this->validate($value);
+    }
+
+    /**
+     * Tells whether the given token matches one of the accepted GitHub token formats.
+     *
+     * Exposed so other token sources (e.g. a token read from a file or an environment variable) can
+     * validate against the very same definition without duplicating the pattern.
+     */
+    public function isValidFormat(string $token): bool
+    {
+        return 1 === preg_match(self::FORMAT_PATTERN, $token);
     }
 
     private function askForValue(InputInterface $input, OutputInterface $output, QuestionHelper $questionHelper, ?int $maxAttempts = null): string
     {
-        $validationCallback = $this->getValidationCallback();
-        $question           = new Question('Please, provide your GitHub token: ');
+        $question = new Question('Please, provide your GitHub token: ');
         $question->setHidden(false);
         $question->setMaxAttempts($maxAttempts ?? self::MAX_ATTEMPTS);
-        $question->setValidator($validationCallback);
+        $question->setValidator($this->validate(...));
 
         try {
             $token = $questionHelper->ask($input, $output, $question);
@@ -65,17 +82,17 @@ class GitHubTokenCommandOption
             throw new MissingInputException('You must pass a valid token of the repo.', previous: $exception);
         }
 
-        return $token;
+        // Re-validate the answer: besides being defensive, it narrows the QuestionHelper's `mixed`
+        // return type down to `string` for the static analysers.
+        return $this->validate($token);
     }
 
-    private function getValidationCallback(): callable
+    private function validate(mixed $gitHubToken): string
     {
-        return static function (mixed $gitHubToken): string {
-            if (0 === preg_match('/^ghp_[A-Za-z0-9]{36}$/', $gitHubToken)) {
-                throw new InvalidOptionException('The GitHub Token format is invalid.');
-            }
+        if (false === is_string($gitHubToken) || false === $this->isValidFormat($gitHubToken)) {
+            throw new InvalidOptionException('The GitHub Token format is invalid.');
+        }
 
-            return $gitHubToken;
-        };
+        return $gitHubToken;
     }
 }

--- a/tests/Console/Command/Params/Options/GitHubTokenCommandOptionTest.php
+++ b/tests/Console/Command/Params/Options/GitHubTokenCommandOptionTest.php
@@ -37,6 +37,39 @@ class GitHubTokenCommandOptionTest extends TestCase
         $this->gitHubTokenCommandOption = new GitHubTokenCommandOption();
     }
 
+    public function testIsValidFormatAcceptsAllSupportedTokenShapes(): void
+    {
+        // Classic personal access token: ghp_ + 36 alphanumerics.
+        $this->assertTrue($this->gitHubTokenCommandOption->isValidFormat('ghp_' . str_repeat('a', 36)));
+        // Fine-grained personal access token: github_pat_ + 82 chars (alphanumerics and underscores).
+        $this->assertTrue($this->gitHubTokenCommandOption->isValidFormat('github_pat_' . str_repeat('A', 82)));
+        // App / installation access token: ghs_ + 36 alphanumerics.
+        $this->assertTrue($this->gitHubTokenCommandOption->isValidFormat('ghs_' . str_repeat('0', 36)));
+    }
+
+    public function testIsValidFormatRejectsUnknownOrMalformedShapes(): void
+    {
+        $this->assertFalse($this->gitHubTokenCommandOption->isValidFormat('invalid-git-hub-token'));
+        $this->assertFalse($this->gitHubTokenCommandOption->isValidFormat('ghp_tooShort'));
+        $this->assertFalse($this->gitHubTokenCommandOption->isValidFormat('github_pat_' . str_repeat('a', 10)));
+        $this->assertFalse($this->gitHubTokenCommandOption->isValidFormat(''));
+    }
+
+    public function testGetValueOrNullAcceptsAFineGrainedPat(): void
+    {
+        $fineGrainedToken = 'github_pat_' . str_repeat('A', 82);
+        $expectedOutput   = sprintf('%s%s%s', GitHubTokenCommandOptionTest::GITHUB_TOKEN_START, $fineGrainedToken, GitHubTokenCommandOptionTest::GITHUB_TOKEN_END);
+
+        $command       = $this->createCommandForGetValueOrNull();
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([
+            '--' . $this->gitHubTokenCommandOption::NAME => $fineGrainedToken,
+        ]);
+
+        $this->assertStringContainsString($expectedOutput, $commandTester->getDisplay());
+    }
+
     public function testGetValueOrAskWithValidGitHubTokenProvidedReturnsTheProvidedGitHubToken(): void
     {
         $testGitHubToken  = 'ghp_1234567890abcdef1234567890abcdef1234';


### PR DESCRIPTION
## What

Accept fine-grained PATs (`github_pat_…`) and app/installation tokens (`ghs_…`) alongside classic `ghp_…`, validated through a **single shared definition**.

## Why

Token validation was hardcoded to `^ghp_[A-Za-z0-9]{36}$` in **two** places (the option and `AbstractCommand::readTokenFromFile`), rejecting fine-grained PATs — the modern default and common in CI. The bug already affected `--token` and the config-file path today.

## Changes

- `GitHubTokenCommandOption`: one `FORMAT_PATTERN` (classic + fine-grained + app), a new public `isValidFormat()` reused by every source; replaced the `callable`-returning-`mixed` with a typed `validate(mixed): string` + `is_string()` guard (same pattern as #43) — this removes **5 phpstan baseline entries** instead of masking them.
- `AbstractCommand::readTokenFromFile` now calls `isValidFormat()` (no duplicated regex); dropped the now-unused `Safe\preg_match` import.
- Baseline: removed the 5 `GitHubTokenCommandOption` mixed-return entries (fixed, not masked).
- Tests: `isValidFormat` accepts/rejects each shape; a fine-grained PAT is accepted end-to-end.
- README: documents the accepted token formats.

## Notes

Standalone, atomic PR off `master`. Logically independent from the `GH_MATRIX_TOKEN` env-var issue (this format bug exists today on `--token`/file). Driver context: TrustBack.Me `#5382`.

Closes #54
