### PR TITLE
feat: add a "--check" option to "sync" for CI drift detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ vendor/bin/github-actions-matrix sync [options]
 - `-w, --workflows-dir=WORKFLOWS-DIR` - The folder that directly contains the workflow `*.yml`/`*.yaml` files (non-standard layouts)
 - `-f, --force` - Apply the changes without asking for confirmation (e.g. in CI)
 - `--dry-run` - Show what would change without touching the branch protection (read-only preview)
+- `--check` - CI gate: read-only, exit `0` if aligned, `1` if drift, `2` on error (implies `--dry-run`)
 
 **Example:**
 ```bash
@@ -97,6 +98,8 @@ This command will:
 2. Add new protection rules based on your workflow matrices
 
 Before applying any change, `sync` shows the plan and asks for confirmation. Pass `-f, --force` to skip the prompt (for example in CI).
+
+To **verify** alignment in CI without changing anything, use `sync --check`: it is read-only and encodes the result in the exit code — `0` if the branch protection matches the workflows, `1` if it drifts, `2` on error (bad token, network, parse). It needs a token with read access to the branch protection.
 
 ### Configuration File
 

--- a/src/Console/Command/Params/Options/CheckCommandOption.php
+++ b/src/Console/Command/Params/Options/CheckCommandOption.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Aerendir GitHub Actions Matrix.
+ *
+ * Copyright (c) Adamo Aerendir Crespi <aerendir@serendipityhq.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options;
+
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * CI gate: read-only check that exits non-zero when the branch protection drifts from the workflows.
+ *
+ * A boolean (`VALUE_NONE`) flag: it is never prompted for, so only `isEnabled()` is needed.
+ */
+final class CheckCommandOption
+{
+    public const string NAME = 'check';
+
+    public function isEnabled(InputInterface $input): bool
+    {
+        return true === $input->getOption(self::NAME);
+    }
+}

--- a/src/Console/Command/SyncCommand.php
+++ b/src/Console/Command/SyncCommand.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Aerendir\Bin\GitHubActionsMatrix\Console\Command;
 
 use Aerendir\Bin\GitHubActionsMatrix\Config\GHMatrixConfig;
+use Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options\CheckCommandOption;
 use Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options\DryRunCommandOption;
 use Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options\ForceCommandOption;
 use Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options\GitHubTokenCommandOption;
@@ -41,6 +42,12 @@ final class SyncCommand extends AbstractCommand
 {
     public const string COMMAND_NAME = 'sync';
 
+    /** Exit code returned by --check when the branch protection drifts from the workflows. */
+    private const int EXIT_DRIFT = 1;
+
+    /** Exit code returned by --check when the check itself fails (bad token, network, parse error). */
+    private const int EXIT_ERROR = 2;
+
     public function __construct(
         ?GHMatrixConfig $config = null,
         ?GitHubUsernameCommandOption $gitHubUsernameCommandOption = null,
@@ -55,6 +62,7 @@ final class SyncCommand extends AbstractCommand
         ?WorkflowsDirCommandOption $workflowsDirCommandOption = null,
         private readonly ForceCommandOption $forceCommandOption = new ForceCommandOption(),
         private readonly DryRunCommandOption $dryRunCommandOption = new DryRunCommandOption(),
+        private readonly CheckCommandOption $checkCommandOption = new CheckCommandOption(),
     ) {
         parent::__construct(
             $config,
@@ -77,7 +85,20 @@ final class SyncCommand extends AbstractCommand
 
         $io->title('Protection rules sync');
 
-        $this->init($input, $output);
+        $isCheck = $this->isCheck($input);
+
+        try {
+            $this->init($input, $output);
+        } catch (\Throwable $throwable) {
+            // In --check mode (CI gate) report the failure as a distinct exit code instead of bubbling up.
+            if ($isCheck) {
+                $io->error($throwable->getMessage());
+
+                return self::EXIT_ERROR;
+            }
+
+            throw $throwable;
+        }
 
         $repoUsername               = $this->getRepoUsername();
         $repoName                   = $this->getRepoName();
@@ -98,6 +119,19 @@ final class SyncCommand extends AbstractCommand
             foreach ($remoteCombinationsToCreate as $combination) {
                 $io->writeln(' - ' . $combination);
             }
+        }
+
+        // --check is a CI gate: read-only, no prompt, with the drift encoded in the exit code.
+        if ($isCheck) {
+            if ([] === $remoteCombinationsToRemove && [] === $remoteCombinationsToCreate) {
+                $io->success('In sync: the branch protection matches the workflows.');
+
+                return self::SUCCESS;
+            }
+
+            $io->warning('Drift detected: the branch protection is not aligned with the workflows.');
+
+            return self::EXIT_DRIFT;
         }
 
         // --dry-run is a read-only preview: the plan was printed above, stop before any change.
@@ -135,6 +169,7 @@ final class SyncCommand extends AbstractCommand
 
         $this->addOption(ForceCommandOption::NAME, ForceCommandOption::SHORTCUT, InputOption::VALUE_NONE, 'Apply the changes without asking for confirmation.');
         $this->addOption(DryRunCommandOption::NAME, null, InputOption::VALUE_NONE, 'Show what would change without touching the branch protection (read-only preview).');
+        $this->addOption(CheckCommandOption::NAME, null, InputOption::VALUE_NONE, 'CI gate: read-only, exit 0 if aligned, 1 if drift, 2 on error. Implies --dry-run.');
     }
 
     /**
@@ -171,5 +206,10 @@ final class SyncCommand extends AbstractCommand
     private function isDryRun(InputInterface $input): bool
     {
         return $this->dryRunCommandOption->isEnabled($input);
+    }
+
+    private function isCheck(InputInterface $input): bool
+    {
+        return $this->checkCommandOption->isEnabled($input);
     }
 }

--- a/tests/Console/Command/Params/Options/CheckCommandOptionTest.php
+++ b/tests/Console/Command/Params/Options/CheckCommandOptionTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Aerendir GitHub Actions Matrix.
+ *
+ * Copyright (c) Adamo Aerendir Crespi <aerendir@serendipityhq.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Aerendir\Bin\GitHubActionsMatrix\Tests\Console\Command\Params\Options;
+
+use Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options\CheckCommandOption;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class CheckCommandOptionTest extends TestCase
+{
+    public const string CHECK_START = '<<<CHECK ';
+    public const string CHECK_END   = '>>>';
+
+    public function testIsEnabledReturnsTrueWhenTheFlagIsPassed(): void
+    {
+        $command       = $this->createCommandForIsEnabled();
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([
+            '--' . CheckCommandOption::NAME => true,
+        ]);
+
+        $this->assertStringContainsString(sprintf('%s%s%s', self::CHECK_START, 'yes', self::CHECK_END), $commandTester->getDisplay());
+    }
+
+    public function testIsEnabledReturnsFalseWhenTheFlagIsNotPassed(): void
+    {
+        $command       = $this->createCommandForIsEnabled();
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([]);
+
+        $this->assertStringContainsString(sprintf('%s%s%s', self::CHECK_START, 'no', self::CHECK_END), $commandTester->getDisplay());
+    }
+
+    private function createCommandForIsEnabled(): Command
+    {
+        return new class extends Command {
+            private readonly CheckCommandOption $checkCommandOption;
+
+            public function __construct()
+            {
+                parent::__construct('test-check-option-is-enabled');
+                $this->checkCommandOption = new CheckCommandOption();
+            }
+
+            #[\Override]
+            protected function configure(): void
+            {
+                $this->addOption(
+                    CheckCommandOption::NAME,
+                    null,
+                    InputOption::VALUE_NONE,
+                    'CI gate: read-only, exit 0 if aligned, 1 if drift, 2 on error. Implies --dry-run.',
+                );
+            }
+
+            #[\Override]
+            protected function execute(InputInterface $input, OutputInterface $output): int
+            {
+                $enabled = $this->checkCommandOption->isEnabled($input) ? 'yes' : 'no';
+
+                $output->writeln(sprintf('%s%s%s', CheckCommandOptionTest::CHECK_START, $enabled, CheckCommandOptionTest::CHECK_END));
+
+                return Command::SUCCESS;
+            }
+        };
+    }
+}

--- a/tests/Console/Command/SyncCommandTest.php
+++ b/tests/Console/Command/SyncCommandTest.php
@@ -16,6 +16,8 @@ namespace Aerendir\Bin\GitHubActionsMatrix\Tests\Console\Command;
 use Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options\GitHubTokenCommandOption;
 use Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options\GitHubUsernameCommandOption;
 use Aerendir\Bin\GitHubActionsMatrix\Console\Command\SyncCommand;
+use Github\Api\Repo;
+use Github\Api\Repository\Protection;
 use Github\Client;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Application;
@@ -106,6 +108,64 @@ class SyncCommandTest extends CommandTestCase
         $this->assertStringNotContainsString('Sync completed', $output);
     }
 
+    public function testCheckReturnsZeroWhenInSync(): void
+    {
+        // The remote contexts exactly match the local required checks: no drift.
+        $commandTester = $this->createCheckCommandTester([
+            'phpcs (8.3)',
+            'phpcs (8.4)',
+            'rector (8.3)',
+            'rector (8.4)',
+        ]);
+
+        $commandTester->execute([
+            '--' . GitHubUsernameCommandOption::NAME => self::TEST_USERNAME,
+            '--' . GitHubTokenCommandOption::NAME    => self::TEST_TOKEN,
+            '--check'                                => true,
+        ]);
+
+        $this->assertSame(0, $commandTester->getStatusCode());
+        $this->assertStringContainsString('In sync', $commandTester->getDisplay());
+    }
+
+    public function testCheckReturnsOneWhenDriftIsDetected(): void
+    {
+        $commandTester = $this->createSyncCommandTester();
+
+        $commandTester->execute([
+            '--' . GitHubUsernameCommandOption::NAME => self::TEST_USERNAME,
+            '--' . GitHubTokenCommandOption::NAME    => self::TEST_TOKEN,
+            '--check'                                => true,
+        ]);
+
+        $this->assertSame(1, $commandTester->getStatusCode());
+        $this->assertStringContainsString('Drift detected', $commandTester->getDisplay());
+    }
+
+    public function testCheckReturnsTwoOnError(): void
+    {
+        $commandTester = $this->createFailingCommandTester();
+
+        $commandTester->execute([
+            '--' . GitHubUsernameCommandOption::NAME => self::TEST_USERNAME,
+            '--' . GitHubTokenCommandOption::NAME    => self::TEST_TOKEN,
+            '--check'                                => true,
+        ]);
+
+        $this->assertSame(2, $commandTester->getStatusCode());
+    }
+
+    public function testErrorPropagatesWhenNotInCheckMode(): void
+    {
+        $commandTester = $this->createFailingCommandTester();
+
+        $this->expectException(\RuntimeException::class);
+        $commandTester->execute([
+            '--' . GitHubUsernameCommandOption::NAME => self::TEST_USERNAME,
+            '--' . GitHubTokenCommandOption::NAME    => self::TEST_TOKEN,
+        ]);
+    }
+
     private function createSyncCommandTester(): CommandTester
     {
         $mockRepoReader      = $this->createMockReader(self::TEST_REPO);
@@ -114,6 +174,59 @@ class SyncCommandTest extends CommandTestCase
         $this->updateMockGitHubClient($mockGitHubClient, self::TEST_USERNAME, self::TEST_REPO);
 
         $command = new SyncCommand(repoReader: $mockRepoReader, workflowsReader: $mockWorkflowsReader, githubClient: $mockGitHubClient);
+
+        $application = new Application();
+        $application->addCommand($command);
+
+        return new CommandTester($command);
+    }
+
+    /**
+     * Builds a tester whose remote branch protection exposes exactly the given required-check contexts,
+     * so the test controls whether the local workflows are in sync or drifting.
+     *
+     * @param array<string> $remoteContexts
+     */
+    private function createCheckCommandTester(array $remoteContexts): CommandTester
+    {
+        $mockProtection = $this->createMock(Protection::class);
+        $mockProtection->method('show')->willReturn([
+            'required_status_checks' => ['contexts' => $remoteContexts],
+        ]);
+
+        $mockRepo = $this->createMock(Repo::class);
+        $mockRepo->method('protection')->willReturn($mockProtection);
+        $mockRepo->method('branches')->willReturn([]);
+
+        $mockClient = $this->createMock(Client::class);
+        $mockClient->method('authenticate');
+        $mockClient->method('api')->willReturn($mockRepo);
+
+        $command = new SyncCommand(
+            repoReader: $this->createMockReader(self::TEST_REPO),
+            workflowsReader: $this->createMockWorkflowsReader(),
+            githubClient: $mockClient
+        );
+
+        $application = new Application();
+        $application->addCommand($command);
+
+        return new CommandTester($command);
+    }
+
+    /**
+     * Builds a tester whose GitHub client fails during authentication, to exercise the error paths.
+     */
+    private function createFailingCommandTester(): CommandTester
+    {
+        $mockClient = $this->createMock(Client::class);
+        $mockClient->method('authenticate')->willThrowException(new \RuntimeException('Authentication failed'));
+
+        $command = new SyncCommand(
+            repoReader: $this->createMockReader(self::TEST_REPO),
+            workflowsReader: $this->createMockWorkflowsReader(),
+            githubClient: $mockClient
+        );
 
         $application = new Application();
         $application->addCommand($command);


### PR DESCRIPTION
## Stack context

Final of the 3-PR sync stack: confirmation + `--force` (#63) → `--dry-run` + remove `compare` (#64) → **`--check` (this)**. **Stacked on #64.**

## What

Adds `sync --check`: a read-only CI gate that encodes the drift in the **exit code** — `0` aligned, `1` drift, `2` error.

## Why

CI needs to assert "branch protection matches the workflows" and fail the build otherwise. `--check` is read-only (never writes, never prompts) and **distinguishes drift (`1`) from a genuine failure (`2`)** — a broken check (bad token, network, parse error) must not masquerade as "aligned".

## Changes

- `SyncCommand`: `--check` option; `init()` wrapped so that in check mode a failure returns exit `2` (outside check mode the exception still propagates unchanged); aligned → `0`, drift → `1`. `--check` is inherently read-only (it returns before the confirm/apply step), so it implies `--dry-run`.
- Tests: aligned → `0`, drift → `1`, error → `2`, and the error still propagates without `--check`. `SyncCommand` is fully covered.
- README: documents `--check`, the CI usage and the exit codes.

Closes #51
