### PR TITLE
feat: preserve external/non-workflow required checks on sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,16 @@ $config->ignoreJob('deploy');
 
 An ignored job is **never added** to the branch protection and, if it is currently required, it is **removed** by `sync`.
 
+### External / non-workflow required checks
+
+Some required checks (codecov, kodiak, GitGuardian, …) come from external apps and live in **no** workflow file, so the tool cannot derive them. Declare them with `addRequiredCheck()` so `sync` treats them as part of the desired set:
+
+```php
+$config->addRequiredCheck('codecov');
+```
+
+A declared check is **never removed** by `sync` (and is added if it is not yet required). This is what lets `sync` remove a stale matrix context for real, without ever deleting a check it simply cannot read from the workflows.
+
 <hr />
 <h3 align="center">
     <b>Do you like this library?</b><br />

--- a/src/Config/GHMatrixConfig.php
+++ b/src/Config/GHMatrixConfig.php
@@ -28,6 +28,9 @@ final class GHMatrixConfig
     /** @var array<string> */
     private array $ignoredJobs = [];
 
+    /** @var array<string> */
+    private array $requiredChecks = [];
+
     public function getUser(): ?string
     {
         return $this->user;
@@ -165,5 +168,29 @@ final class GHMatrixConfig
     public function getIgnoredJobs(): array
     {
         return $this->ignoredJobs;
+    }
+
+    /**
+     * Declare an external / non-workflow required check (e.g. `codecov`) that lives in no workflow file.
+     *
+     * Declared checks become part of the desired set as bare-name contexts: they are never removed by
+     * `sync` and, if not yet required, they are added — so `sync` can remove a stale matrix context for
+     * real without ever deleting a check it simply cannot read from the workflows.
+     */
+    public function addRequiredCheck(string $checkName): void
+    {
+        if ('' === $checkName) {
+            throw new \InvalidArgumentException('The required check name cannot be empty.');
+        }
+
+        $this->requiredChecks[] = $checkName;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getRequiredChecks(): array
+    {
+        return $this->requiredChecks;
     }
 }

--- a/src/Console/Command/AbstractCommand.php
+++ b/src/Console/Command/AbstractCommand.php
@@ -118,7 +118,8 @@ abstract class AbstractCommand extends Command
         // git root) and passed to read(): the reader itself is a plain injected collaborator.
         $workflowCandidates = $this->resolveWorkflowCandidates($input);
         $ignoredJobs        = $this->config->getIgnoredJobs();
-        $this->localJobs    = $this->workflowsReader->read($workflowCandidates, $ignoredJobs);
+        $requiredChecks     = $this->config->getRequiredChecks();
+        $this->localJobs    = $this->workflowsReader->read($workflowCandidates, $ignoredJobs, $requiredChecks);
 
         $this->githubClient->authenticate(tokenOrLogin: $repoToken, authMethod: AuthMethod::ACCESS_TOKEN);
         $repo = $this->githubClient->api('repo');

--- a/src/ValueObject/Job.php
+++ b/src/ValueObject/Job.php
@@ -60,6 +60,15 @@ final class Job
         return $this->matrix;
     }
 
+    /**
+     * Builds a "bare-name" job for an external / non-workflow required check (e.g. codecov): a single
+     * required context equal to the given check name. Reuses the non-matrix job representation.
+     */
+    public static function fromContextName(string $contextName): self
+    {
+        return self::createNonMatrixJob($contextName, 'config', 'config', $contextName);
+    }
+
     private static function createNonMatrixJob(string $name, string $workflowFilename, string $workflowName, string $job): self
     {
         $combination = new Combination([], $workflowFilename, $workflowName, $job);

--- a/src/Workflow/Reader.php
+++ b/src/Workflow/Reader.php
@@ -30,13 +30,21 @@ class Reader
      * @param array<array-key, string> $possibleFolders explicit folders to look into, in priority order;
      *                                                  the Finder appends the package fallbacks after them
      * @param array<array-key, string> $ignoredJobs     job ids to exclude from the computed set entirely
+     * @param array<array-key, string> $requiredChecks  external / non-workflow checks to preserve as
+     *                                                  bare-name required contexts (e.g. codecov)
      */
-    public function read(array $possibleFolders = [], array $ignoredJobs = []): JobsCollection
+    public function read(array $possibleFolders = [], array $ignoredJobs = [], array $requiredChecks = []): JobsCollection
     {
         $localJobs = new JobsCollection();
         foreach ($this->finder->getWorkflows($possibleFolders) as $workflowFile) {
             $readCollection = $this->createFromYaml($workflowFile, $ignoredJobs);
             $localJobs->mergeCollection($readCollection);
+        }
+
+        // External / non-workflow required checks (e.g. codecov) enter the desired set as bare-name jobs,
+        // so sync preserves them like any other required context instead of removing what it cannot read.
+        foreach ($requiredChecks as $checkName) {
+            $localJobs->addOrMergeJob(Job::fromContextName($checkName));
         }
 
         return $localJobs;

--- a/tests/Config/GHMatrixConfigTest.php
+++ b/tests/Config/GHMatrixConfigTest.php
@@ -287,4 +287,29 @@ class GHMatrixConfigTest extends TestCase
         $this->expectExceptionMessage('The job name cannot be empty.');
         $config->ignoreJob('');
     }
+
+    public function testGetRequiredChecksReturnsEmptyArrayInitially(): void
+    {
+        $config = new GHMatrixConfig();
+
+        $this->assertSame([], $config->getRequiredChecks());
+    }
+
+    public function testAddRequiredCheckAddsTheCheck(): void
+    {
+        $config = new GHMatrixConfig();
+        $config->addRequiredCheck('codecov');
+        $config->addRequiredCheck('kodiak');
+
+        $this->assertSame(['codecov', 'kodiak'], $config->getRequiredChecks());
+    }
+
+    public function testAddRequiredCheckThrowsOnEmptyName(): void
+    {
+        $config = new GHMatrixConfig();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The required check name cannot be empty.');
+        $config->addRequiredCheck('');
+    }
 }

--- a/tests/Workflow/ComparatorTest.php
+++ b/tests/Workflow/ComparatorTest.php
@@ -195,4 +195,26 @@ class ComparatorTest extends TestCase
         $this->assertContains('phpunit (8.3)', $jobIds);
         $this->assertNotContains('phpunit (8.4)', $jobIds);
     }
+
+    public function testCompareDoesNotRemoveDeclaredExternalChecks(): void
+    {
+        // "codecov" is a declared external check, injected as a bare-name job (as the Reader does).
+        $phpCsMatrix = Matrix::createFromArray(['php' => ['8.3']], 'phpcs.yml', 'PHP CS', 'phpcs');
+
+        $localJobsCollection = new JobsCollection();
+        $localJobsCollection->addJob(new Job('phpcs', $phpCsMatrix));
+        $localJobsCollection->addJob(Job::fromContextName('codecov'));
+
+        $remoteJobIds = [
+            'phpcs (8.3)',
+            'codecov',      // external check currently required -> must be preserved
+            'rector (8.2)', // stale matrix context -> must be removed
+        ];
+
+        $comparator   = new Comparator();
+        $jobsToRemove = $comparator->compare($localJobsCollection, $remoteJobIds);
+
+        $this->assertNotContains('codecov', $jobsToRemove);
+        $this->assertSame(['rector (8.2)'], $jobsToRemove);
+    }
 }

--- a/tests/Workflow/ReaderTest.php
+++ b/tests/Workflow/ReaderTest.php
@@ -211,4 +211,34 @@ class ReaderTest extends TestCase
         unlink($phpCsFileInfo->getPathname());
         unlink($rectorFileInfo->getPathname());
     }
+
+    public function testReadInjectsExternalRequiredChecksAsBareNameJobs(): void
+    {
+        $workflowContent = <<<YAML
+            name: CI
+            on: [push]
+            jobs:
+              phpcs:
+                strategy:
+                  matrix:
+                    php: [ '8.3', '8.4' ]
+                steps:
+                  - uses: actions/checkout@v3
+            YAML;
+
+        $fileInfo = $this->createTempFile($workflowContent, 'phpcs');
+
+        $finder = $this->createMock(Finder::class);
+        $finder->method('getWorkflows')->willReturn(new \ArrayIterator([$fileInfo]));
+
+        $reader         = new Reader($finder);
+        $jobsCollection = $reader->read([], [], ['codecov']);
+
+        $this->assertTrue($jobsCollection->hasJob('phpcs'));
+        // The external check is present as a bare-name job whose single context equals the check name.
+        $this->assertTrue($jobsCollection->hasJob('codecov'));
+        $this->assertArrayHasKey('codecov', $jobsCollection->getJob('codecov')->getMatrix()->getCombinations());
+
+        unlink($fileInfo->getPathname());
+    }
 }


### PR DESCRIPTION
## Stack context

2nd of "stack B": handle non-matrix jobs (#66) → **preserve external/non-workflow checks (this)**. **Stacked on #66.** Reuses the bare-name context introduced there.

## What

Declare external / non-workflow required checks (codecov, kodiak, GitGuardian, …) with `addRequiredCheck()`; `sync` preserves them (never removes; adds if not yet required).

## Why

External checks live in **no** workflow file, so the tool cannot derive them: they sit in branch protection but not in the computed set → `getToRemove = remote − local` flags them → `sync` would delete them. Declaring them puts them in the **desired set** as bare-name contexts, so "not found locally" stops meaning "couldn't read it". This is exactly what makes `sync`'s removal safe.

## Changes

- `GHMatrixConfig`: `addRequiredCheck()` / `getRequiredChecks()` (empty name → throw).
- `Job::fromContextName()`: a bare-name job factory for a check, reusing the non-matrix representation from #55.
- `Reader::read()` injects the declared checks as bare-name jobs; `AbstractCommand` threads `config.getRequiredChecks()`.
- **No Comparator change** — external checks are just regular bare-name jobs in the desired set, so the existing diff logic preserves them.
- Tests: config methods; the reader injects the check; the comparator preserves a declared check while still removing a stale matrix context. Fully covered.
- README: an `addRequiredCheck` section.

Closes #56
