### PR TITLE
feat: resolve the GitHub token from an environment variable (GH_MATRIX_TOKEN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Every value can be provided on the command line or declared in the configuration
 | `setProjectDir(string)` | `-p, --project-dir` | Project root that contains `.github/workflows`; also the preferred base directory for the token file. |
 | `setWorkflowsDir(string)` | `-w, --workflows-dir` | Folder that directly contains the workflow `*.yml`/`*.yaml` files. Escape hatch for non-standard layouts. |
 
-> The GitHub token must have **repo-admin** scope. Classic (`ghp_…`), fine-grained (`github_pat_…`) and app/installation (`ghs_…`) tokens are accepted. Provide it via `setTokenFile()` (pointing at a gitignored file) or `-t, --token` — never commit it.
+> The GitHub token must have **repo-admin** scope. Classic (`ghp_…`), fine-grained (`github_pat_…`) and app/installation (`ghs_…`) tokens are accepted. Provide it via `-t, --token`, the `GH_MATRIX_TOKEN` environment variable (recommended in CI — it keeps the secret off disk and out of the process arguments), or `setTokenFile()` (pointing at a gitignored file) — never commit it. Resolution order: `--token` → `GH_MATRIX_TOKEN` (env) → token file → interactive prompt.
 
 #### Priority Order
 

--- a/src/Console/Command/AbstractCommand.php
+++ b/src/Console/Command/AbstractCommand.php
@@ -41,6 +41,9 @@ use function Safe\realpath;
 
 abstract class AbstractCommand extends Command
 {
+    /** Environment variable read as a CI-friendly token source (priority 2, after the CLI option). */
+    private const string TOKEN_ENV_VAR = 'GH_MATRIX_TOKEN';
+
     protected readonly string $branchName;
     private readonly GHMatrixConfig $config;
     private readonly GitHubUsernameCommandOption $gitHubUsernameCommandOption;
@@ -177,7 +180,13 @@ abstract class AbstractCommand extends Command
             return $cliToken;
         }
 
-        // Priority 2: Token file from config
+        // Priority 2: environment variable (CI-friendly: keeps the secret off disk and out of argv)
+        $envToken = $this->readTokenFromEnv();
+        if (null !== $envToken) {
+            return $envToken;
+        }
+
+        // Priority 3: Token file from config
         $tokenFilePath = $this->config->getTokenFile();
         if (null !== $tokenFilePath) {
             $token = $this->readTokenFromFile($tokenFilePath);
@@ -186,7 +195,7 @@ abstract class AbstractCommand extends Command
             }
         }
 
-        // Priority 3: Ask the user
+        // Priority 4: Ask the user
         return $this->gitHubTokenCommandOption->getValueOrAsk($input, $output, $questionHelper);
     }
 
@@ -277,6 +286,30 @@ abstract class AbstractCommand extends Command
     protected function getCombinationsToRemove(): array
     {
         return $this->combinationsToRemove;
+    }
+
+    /**
+     * Reads the token from the {@see self::TOKEN_ENV_VAR} environment variable: the preferred source in
+     * CI, since it keeps the secret off disk (unlike the token file) and out of the process arguments
+     * (unlike `--token`). An unset, empty or malformed value falls back to the next source.
+     */
+    private function readTokenFromEnv(): ?string
+    {
+        $token = getenv(self::TOKEN_ENV_VAR);
+        if (false === $token) {
+            return null;
+        }
+
+        $token = trim($token);
+
+        // Validate using the same single source of truth as the option and the token file
+        // (`isValidFormat`), so the env var accepts every supported token format (classic,
+        // fine-grained, app) and an empty or malformed value falls back to the next source.
+        if (false === $this->gitHubTokenCommandOption->isValidFormat($token)) {
+            return null;
+        }
+
+        return $token;
     }
 
     private function readTokenFromFile(string $tokenFilePath): ?string

--- a/tests/Console/Command/ConfigPriorityTest.php
+++ b/tests/Console/Command/ConfigPriorityTest.php
@@ -27,13 +27,25 @@ use function Safe\chdir;
 use function Safe\file_put_contents;
 use function Safe\getcwd;
 use function Safe\mkdir;
+use function Safe\putenv;
 use function Safe\rmdir;
 use function Safe\unlink;
 
 class ConfigPriorityTest extends CommandTestCase
 {
+    private const string TOKEN_ENV_VAR = 'GH_MATRIX_TOKEN';
+
     /** @var string|null Original CWD saved before tests that call chdir() */
     private ?string $originalCwd = null;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Guarantee isolation: the token env var must never leak in from the host or a previous test.
+        putenv(self::TOKEN_ENV_VAR);
+    }
 
     #[\Override]
     protected function tearDown(): void
@@ -45,6 +57,121 @@ class ConfigPriorityTest extends CommandTestCase
             chdir($this->originalCwd);
             $this->originalCwd = null;
         }
+
+        // Never let the token env var leak into the next test.
+        putenv(self::TOKEN_ENV_VAR);
+    }
+
+    public function testEnvTokenUsedWhenCliNotProvided(): void
+    {
+        $envToken = 'ghp_1234567890abcdef1234567890abcdef1234';
+
+        $config = new GHMatrixConfig();
+        $config->setUser('test-user');
+        $config->setBranch('main');
+
+        $command = new SyncCommand(
+            config: $config,
+            repoReader: $this->createMockReader('test-repo'),
+            workflowsReader: $this->createMockWorkflowsReader(),
+            githubClient: $this->createMockGitHubClient()
+        );
+
+        $application = new Application();
+        $application->addCommand($command);
+
+        putenv(self::TOKEN_ENV_VAR . '=' . $envToken);
+
+        $commandTester = new CommandTester($command);
+        // No --token and no interactive input: the token must be taken from the environment variable.
+        $commandTester->execute([]);
+
+        $this->assertEquals(0, $commandTester->getStatusCode());
+    }
+
+    public function testCliTokenTakesPrecedenceOverEnvToken(): void
+    {
+        $cliToken = 'ghp_1234567890abcdef1234567890abcdef1234';
+
+        $config = new GHMatrixConfig();
+        $config->setUser('test-user');
+        $config->setBranch('main');
+
+        $command = new SyncCommand(
+            config: $config,
+            repoReader: $this->createMockReader('test-repo'),
+            workflowsReader: $this->createMockWorkflowsReader(),
+            githubClient: $this->createMockGitHubClient()
+        );
+
+        $application = new Application();
+        $application->addCommand($command);
+
+        // The env token is invalid; the command only succeeds if the CLI option is read first (priority 1).
+        putenv(self::TOKEN_ENV_VAR . '=invalid-env-token');
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            '--' . GitHubTokenCommandOption::NAME => $cliToken,
+        ]);
+
+        $this->assertEquals(0, $commandTester->getStatusCode());
+    }
+
+    public function testInvalidEnvTokenFallsBackToAsking(): void
+    {
+        $promptToken = 'ghp_1234567890abcdef1234567890abcdef1234';
+
+        $config = new GHMatrixConfig();
+        $config->setUser('test-user');
+        $config->setBranch('main');
+
+        $command = new SyncCommand(
+            config: $config,
+            repoReader: $this->createMockReader('test-repo'),
+            workflowsReader: $this->createMockWorkflowsReader(),
+            githubClient: $this->createMockGitHubClient()
+        );
+
+        $application = new Application();
+        $application->addCommand($command);
+
+        // A malformed env token must be ignored, falling back to the interactive prompt.
+        putenv(self::TOKEN_ENV_VAR . '=not-a-valid-token');
+
+        $commandTester = new CommandTester($command);
+        $commandTester->setInputs([$promptToken]);
+        $commandTester->execute([]);
+
+        $this->assertEquals(0, $commandTester->getStatusCode());
+    }
+
+    public function testEmptyEnvTokenFallsBackToAsking(): void
+    {
+        $promptToken = 'ghp_1234567890abcdef1234567890abcdef1234';
+
+        $config = new GHMatrixConfig();
+        $config->setUser('test-user');
+        $config->setBranch('main');
+
+        $command = new SyncCommand(
+            config: $config,
+            repoReader: $this->createMockReader('test-repo'),
+            workflowsReader: $this->createMockWorkflowsReader(),
+            githubClient: $this->createMockGitHubClient()
+        );
+
+        $application = new Application();
+        $application->addCommand($command);
+
+        // An empty env token must be ignored, falling back to the interactive prompt.
+        putenv(self::TOKEN_ENV_VAR . '=');
+
+        $commandTester = new CommandTester($command);
+        $commandTester->setInputs([$promptToken]);
+        $commandTester->execute([]);
+
+        $this->assertEquals(0, $commandTester->getStatusCode());
     }
 
     public function testCliOptionOverridesConfigForUsername(): void


### PR DESCRIPTION
## What

Resolve the GitHub token from the **`GH_MATRIX_TOKEN`** environment variable, as **priority 2** — after `--token`, before the token file and the interactive prompt.

## Why

CI needs a token source that neither materialises a secret on disk (the token file) nor leaks it into `argv`/logs (`--token`). An environment variable is the standard, safe CI mechanism. A dedicated name (`GH_MATRIX_TOKEN`, **not** `GITHUB_TOKEN`) avoids colliding with the ephemeral token GitHub Actions auto-injects, which lacks the admin rights needed for branch protection.

## Changes

- `AbstractCommand`: new `readTokenFromEnv()` reading `GH_MATRIX_TOKEN`; inserted as priority 2 in `getRepoToken` (`--token` → env → token file → prompt). An unset, empty or malformed value falls back to the next source.
- Tests: env token used when CLI absent; CLI takes precedence over env; invalid and empty env tokens fall back to the prompt — with strict env isolation in `setUp`/`tearDown`.
- README: documents the env var and the full token-resolution order.

## Notes

Standalone, atomic PR off `master`. Logically independent from the fine-grained PAT issue: this validates with the same classic-PAT check as the other sources today; the two changes combine once both land. Driver context: TrustBack.Me `#5382`.

Closes #53



---
> ↻ Recreates #61 (auto-closed when `master` history was rewritten to strip commit trailers; GitHub blocks reopening a force-pushed closed PR). Same branch `feat-token-from-env`, same diff.
>
> Addresses @Aerendir's review on #61: the env token is now validated through `GitHubTokenCommandOption::isValidFormat()` (all three token formats — classic `ghp_`, fine-grained `github_pat_`, app `ghs_`), replacing the old classic-only regex.
