### PR TITLE
fix: make prompt error handling and null-safety consistent across CommandOption classes

### DIFF
--- a/.baseline-phpstan.neon
+++ b/.baseline-phpstan.neon
@@ -97,36 +97,6 @@ parameters:
 			path: src/Console/Command/AbstractCommand.php
 
 		-
-			message: '#^Method Aerendir\\Bin\\GitHubActionsMatrix\\Console\\Command\\Params\\Options\\GitHubUsernameCommandOption\:\:askForValue\(\) should return string but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Console/Command/Params/Options/GitHubUsernameCommandOption.php
-
-		-
-			message: '#^Method Aerendir\\Bin\\GitHubActionsMatrix\\Console\\Command\\Params\\Options\\GitHubUsernameCommandOption\:\:getValueOrNull\(\) should return string\|null but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Console/Command/Params/Options/GitHubUsernameCommandOption.php
-
-		-
-			message: '#^Method Aerendir\\Bin\\GitHubActionsMatrix\\Console\\Command\\Params\\Options\\RepoBranchCommandOption\:\:askForValue\(\) should return string but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Console/Command/Params/Options/RepoBranchCommandOption.php
-
-		-
-			message: '#^Method Aerendir\\Bin\\GitHubActionsMatrix\\Console\\Command\\Params\\Options\\RepoBranchCommandOption\:\:getValueOrNull\(\) should return string\|null but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Console/Command/Params/Options/RepoBranchCommandOption.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between null and null will always evaluate to true\.$#'
-			identifier: identical.alwaysTrue
-			count: 1
-			path: src/Console/Command/Params/Options/RepoBranchCommandOption.php
-
-		-
 			message: '#^Strict comparison using \=\=\= between null and list\{0\?\: string, 1\?\: non\-empty\-string\} will always evaluate to false\.$#'
 			identifier: identical.alwaysFalse
 			count: 1

--- a/.baseline-psalm.xml
+++ b/.baseline-psalm.xml
@@ -53,9 +53,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[RepoBranchCommandOption]]></code>
     </ClassMustBeFinal>
-    <TypeDoesNotContainType>
-      <code><![CDATA[$branch]]></code>
-    </TypeDoesNotContainType>
   </file>
   <file src="src/Console/Command/Params/Options/RepoNameCommandOption.php">
     <ClassMustBeFinal>

--- a/src/Console/Command/Params/Options/GitHubUsernameCommandOption.php
+++ b/src/Console/Command/Params/Options/GitHubUsernameCommandOption.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options;
 
+use Symfony\Component\Console\Exception\ExceptionInterface;
+use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Exception\MissingInputException;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
@@ -36,7 +38,13 @@ class GitHubUsernameCommandOption
 
     public function getValueOrNull(InputInterface $input): ?string
     {
-        return $input->getOption(self::NAME);
+        $value = $input->getOption(self::NAME);
+
+        if (null === $value) {
+            return null;
+        }
+
+        return $this->validate($value);
     }
 
     private function askForValue(InputInterface $input, OutputInterface $output, QuestionHelper $questionHelper, ?int $maxAttempts = null): string
@@ -44,13 +52,25 @@ class GitHubUsernameCommandOption
         $question = new Question('Please, provide your GitHub username: ');
         $question->setHidden(false);
         $question->setMaxAttempts($maxAttempts ?? self::MAX_ATTEMPTS);
+        $question->setValidator($this->validate(...));
 
         try {
             $username = $questionHelper->ask($input, $output, $question);
-        } catch (MissingInputException $missingInputException) {
-            throw new MissingInputException('You must pass a valid username of the repo.', previous: $missingInputException);
+        } catch (ExceptionInterface $exception) {
+            throw new MissingInputException('You must pass a valid username of the repo.', previous: $exception);
         }
 
-        return $username;
+        // Re-validate the answer: besides being defensive, it narrows the QuestionHelper's `mixed`
+        // return type down to `string` for the static analysers.
+        return $this->validate($username);
+    }
+
+    private function validate(mixed $username): string
+    {
+        if (false === is_string($username) || '' === trim($username)) {
+            throw new InvalidOptionException('The username cannot be empty.');
+        }
+
+        return trim($username);
     }
 }

--- a/src/Console/Command/Params/Options/RepoBranchCommandOption.php
+++ b/src/Console/Command/Params/Options/RepoBranchCommandOption.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options;
 
+use Symfony\Component\Console\Exception\ExceptionInterface;
+use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Exception\MissingInputException;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
@@ -36,17 +38,21 @@ class RepoBranchCommandOption
         }
 
         if (1 === count($protectedBranches)) {
-            return $protectedBranches[0];
+            return array_values($protectedBranches)[0];
         }
 
-        return null === $branch
-            ? $this->askForValue($input, $output, $questionHelper, $protectedBranches, $maxAttempts)
-            : $branch;
+        return $this->askForValue($input, $output, $questionHelper, $protectedBranches, $maxAttempts);
     }
 
     public function getValueOrNull(InputInterface $input): ?string
     {
-        return $input->getOption(self::NAME);
+        $value = $input->getOption(self::NAME);
+
+        if (null === $value) {
+            return null;
+        }
+
+        return $this->validate($value);
     }
 
     /**
@@ -59,10 +65,21 @@ class RepoBranchCommandOption
 
         try {
             $branch = $questionHelper->ask($input, $output, $question);
-        } catch (MissingInputException $missingInputException) {
-            throw new MissingInputException('You must pass a valid branch of the repo.', previous: $missingInputException);
+        } catch (ExceptionInterface $exception) {
+            throw new MissingInputException('You must pass a valid branch of the repo.', previous: $exception);
         }
 
-        return $branch;
+        // Re-validate the answer: besides being defensive, it narrows the QuestionHelper's `mixed`
+        // return type down to `string` for the static analysers.
+        return $this->validate($branch);
+    }
+
+    private function validate(mixed $branch): string
+    {
+        if (false === is_string($branch) || '' === trim($branch)) {
+            throw new InvalidOptionException('The branch cannot be empty.');
+        }
+
+        return trim($branch);
     }
 }

--- a/tests/Console/Command/Params/Options/GitHubUsernameCommandOptionTest.php
+++ b/tests/Console/Command/Params/Options/GitHubUsernameCommandOptionTest.php
@@ -17,6 +17,8 @@ use Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options\GitHubUserna
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidOptionException;
+use Symfony\Component\Console\Exception\MissingInputException;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -33,6 +35,33 @@ class GitHubUsernameCommandOptionTest extends TestCase
     protected function setUp(): void
     {
         $this->gitHubUsernameCommandOption = new GitHubUsernameCommandOption();
+    }
+
+    public function testGetValueOrNullWithAnEmptyUsernameThrowsAnException(): void
+    {
+        $command       = $this->createCommandForGetValueOrNull();
+        $commandTester = new CommandTester($command);
+
+        $this->expectException(InvalidOptionException::class);
+        $this->expectExceptionMessage('The username cannot be empty.');
+        $commandTester->execute([
+            '--' . $this->gitHubUsernameCommandOption::NAME => '',
+        ]);
+    }
+
+    public function testGetValueOrAskThrowsWhenAllAttemptsAreExhausted(): void
+    {
+        $command     = $this->createCommandForGetValueOrAsk();
+        $application = new Application();
+        $application->addCommand($command);
+
+        $commandTester = new CommandTester($command);
+        // An empty answer fails the non-empty validator; with the input exhausted the helper gives up.
+        $commandTester->setInputs(['']);
+
+        $this->expectException(MissingInputException::class);
+        $this->expectExceptionMessage('You must pass a valid username of the repo.');
+        $commandTester->execute([]);
     }
 
     public function testGetValueOrAskWithValidGitHubUsernameProvidedReturnsTheProvidedGitHubUsername(): void

--- a/tests/Console/Command/Params/Options/RepoBranchCommandOptionTest.php
+++ b/tests/Console/Command/Params/Options/RepoBranchCommandOptionTest.php
@@ -17,6 +17,8 @@ use Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options\RepoBranchCo
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidOptionException;
+use Symfony\Component\Console\Exception\MissingInputException;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -33,6 +35,33 @@ class RepoBranchCommandOptionTest extends TestCase
     protected function setUp(): void
     {
         $this->repoBranchCommandOption = new RepoBranchCommandOption();
+    }
+
+    public function testGetValueOrNullWithAnEmptyBranchThrowsAnException(): void
+    {
+        $command       = $this->createCommandForGetValueOrNull();
+        $commandTester = new CommandTester($command);
+
+        $this->expectException(InvalidOptionException::class);
+        $this->expectExceptionMessage('The branch cannot be empty.');
+        $commandTester->execute([
+            '--' . $this->repoBranchCommandOption::NAME => '',
+        ]);
+    }
+
+    public function testGetValueOrAskThrowsWhenAllAttemptsAreExhausted(): void
+    {
+        $command     = $this->createCommandForGetValueOrAsk();
+        $application = new Application();
+        $application->addCommand($command);
+
+        $commandTester = new CommandTester($command);
+        // An answer outside the offered choices is rejected; with the input exhausted the helper gives up.
+        $commandTester->setInputs(['not-a-known-branch']);
+
+        $this->expectException(MissingInputException::class);
+        $this->expectExceptionMessage('You must pass a valid branch of the repo.');
+        $commandTester->execute([]);
     }
 
     public function testGetValueOrAskWithValidRepoBranchProvidedReturnsTheProvidedRepoBranch(): void


### PR DESCRIPTION
## What

Make prompt error handling and null-safety consistent across `GitHubUsernameCommandOption` and `RepoBranchCommandOption`, mirroring the pattern already applied to `RepoNameCommandOption` in #43.

## Why

Both options returned `mixed` (masked by phpstan baseline entries), caught only the Symfony-version-specific `MissingInputException` instead of the broader `ExceptionInterface`, and `RepoBranchCommandOption` carried a dead `null === $branch` comparison (the value is always `null` at that point). The fix **narrows to `string`, broadens the catch, and removes the masked baseline entries** instead of keeping them — per the "fix, don't baseline" rule.

## Changes

- `GitHubUsernameCommandOption`: typed `validate(mixed): string` (non-empty); `getValueOrNull` narrows via `validate`; `askForValue` sets the validator, catches `ExceptionInterface`, and re-validates the answer (narrowing + coverage).
- `RepoBranchCommandOption`: same narrowing; catch `ExceptionInterface`; **removed the dead `null === $branch` ternary**; the `ChoiceQuestion` keeps its built-in choice validator (no custom validator that would break selection), the result is narrowed via `validate`.
- Baselines: removed **5 phpstan** entries (mixed returns + the two dead-comparison ones) and **1 psalm** `TypeDoesNotContainType` entry — fixed, not masked.
- Tests: empty value → `InvalidOptionException`; exhausted attempts → `MissingInputException`, for both options. Both files are now fully covered.

## Notes

Standalone, atomic PR off `master`. Driver context: TrustBack.Me `#5382`.

Closes #45



---
> ↻ Recreates #62 (auto-closed when `master` history was rewritten to strip commit trailers; GitHub blocks reopening a force-pushed closed PR). Same branch `fix-prompt-null-safety-consistency`, same diff.
