### PR TITLE
feat: handle jobs without a "strategy" as a single required check

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,20 @@ $ vendor/bin/github-actions-matrix sync --username different-user --branch dev
 # Uses 'different-user' and 'dev' instead of config values
 ```
 
+### Non-matrix jobs
+
+A job **without** a `strategy.matrix` (for example a single `build` or `deploy` job) maps to **one** required status check whose context is the **bare job name** (e.g. `build`), matching how GitHub names it. Such jobs no longer cause an error.
+
+### Ignoring jobs
+
+Some jobs run in CI but should never gate pull requests (a deploy job, a nightly task, …). Exclude them from the computed set with `ignoreJob()` in `gh-actions-matrix.php`:
+
+```php
+$config->ignoreJob('deploy');
+```
+
+An ignored job is **never added** to the branch protection and, if it is currently required, it is **removed** by `sync`.
+
 <hr />
 <h3 align="center">
     <b>Do you like this library?</b><br />

--- a/src/Config/GHMatrixConfig.php
+++ b/src/Config/GHMatrixConfig.php
@@ -25,6 +25,9 @@ final class GHMatrixConfig
     /** @var array<string, array<array<string, string>>> */
     private array $optionalCombinations = [];
 
+    /** @var array<string> */
+    private array $ignoredJobs = [];
+
     public function getUser(): ?string
     {
         return $this->user;
@@ -138,5 +141,29 @@ final class GHMatrixConfig
     public function getAllOptionalCombinations(): array
     {
         return $this->optionalCombinations;
+    }
+
+    /**
+     * Mark a job (by its job id, as written in the workflow file) as one that must NOT gate pull requests.
+     *
+     * Ignored jobs are excluded from the computed set entirely: they are never added to the branch
+     * protection and, if currently present, they are removed by `sync`. Useful for jobs that should run
+     * but never block merging (e.g. a deploy job).
+     */
+    public function ignoreJob(string $jobName): void
+    {
+        if ('' === $jobName) {
+            throw new \InvalidArgumentException('The job name cannot be empty.');
+        }
+
+        $this->ignoredJobs[] = $jobName;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getIgnoredJobs(): array
+    {
+        return $this->ignoredJobs;
     }
 }

--- a/src/Console/Command/AbstractCommand.php
+++ b/src/Console/Command/AbstractCommand.php
@@ -117,7 +117,8 @@ abstract class AbstractCommand extends Command
         // The candidate folders are resolved at run time (CLI options --project-dir/--workflows-dir, config,
         // git root) and passed to read(): the reader itself is a plain injected collaborator.
         $workflowCandidates = $this->resolveWorkflowCandidates($input);
-        $this->localJobs    = $this->workflowsReader->read($workflowCandidates);
+        $ignoredJobs        = $this->config->getIgnoredJobs();
+        $this->localJobs    = $this->workflowsReader->read($workflowCandidates, $ignoredJobs);
 
         $this->githubClient->authenticate(tokenOrLogin: $repoToken, authMethod: AuthMethod::ACCESS_TOKEN);
         $repo = $this->githubClient->api('repo');

--- a/src/ValueObject/Combination.php
+++ b/src/ValueObject/Combination.php
@@ -32,6 +32,12 @@ class Combination implements \Stringable
 
     public function __toString(): string
     {
+        // A non-matrix job has no combination values: its required-check context on GitHub is the bare
+        // job name (e.g. "build"), without the "(...)" suffix used for matrix combinations.
+        if ([] === $this->combination) {
+            return $this->getJob();
+        }
+
         return sprintf('%s (%s)', $this->getJob(), implode(', ', $this->getCombination()));
     }
 

--- a/src/ValueObject/Job.php
+++ b/src/ValueObject/Job.php
@@ -26,8 +26,10 @@ final class Job
      */
     public static function createFromArray(string $name, array $content, string $workflowFilename, string $workflowName, string $job): self
     {
+        // A job without "strategy", or with a "strategy" that has no "matrix", is not a matrix job: it
+        // maps to a single required check whose context is the bare job name (e.g. "build").
         if (false === array_key_exists('strategy', $content)) {
-            throw new \InvalidArgumentException('The "strategy" key is missing in the provided content.');
+            return self::createNonMatrixJob($name, $workflowFilename, $workflowName, $job);
         }
 
         if (false === is_array($content['strategy'])) {
@@ -35,7 +37,7 @@ final class Job
         }
 
         if (false === array_key_exists('matrix', $content['strategy'])) {
-            throw new \InvalidArgumentException('The "matrix" key is missing in the provided content.');
+            return self::createNonMatrixJob($name, $workflowFilename, $workflowName, $job);
         }
 
         if (false === is_array($content['strategy']['matrix'])) {
@@ -56,5 +58,12 @@ final class Job
     public function getMatrix(): Matrix
     {
         return $this->matrix;
+    }
+
+    private static function createNonMatrixJob(string $name, string $workflowFilename, string $workflowName, string $job): self
+    {
+        $combination = new Combination([], $workflowFilename, $workflowName, $job);
+
+        return new Job($name, new Matrix([(string) $combination => $combination]));
     }
 }

--- a/src/Workflow/Reader.php
+++ b/src/Workflow/Reader.php
@@ -29,19 +29,23 @@ class Reader
     /**
      * @param array<array-key, string> $possibleFolders explicit folders to look into, in priority order;
      *                                                  the Finder appends the package fallbacks after them
+     * @param array<array-key, string> $ignoredJobs     job ids to exclude from the computed set entirely
      */
-    public function read(array $possibleFolders = []): JobsCollection
+    public function read(array $possibleFolders = [], array $ignoredJobs = []): JobsCollection
     {
         $localJobs = new JobsCollection();
         foreach ($this->finder->getWorkflows($possibleFolders) as $workflowFile) {
-            $readCollection = $this->createFromYaml($workflowFile);
+            $readCollection = $this->createFromYaml($workflowFile, $ignoredJobs);
             $localJobs->mergeCollection($readCollection);
         }
 
         return $localJobs;
     }
 
-    public function createFromYaml(SplFileInfo $fileInfo): JobsCollection
+    /**
+     * @param array<array-key, string> $ignoredJobs job ids to skip while reading the workflow
+     */
+    public function createFromYaml(SplFileInfo $fileInfo, array $ignoredJobs = []): JobsCollection
     {
         $parsed = Yaml::parse(file_get_contents($fileInfo->getPathname()));
 
@@ -60,10 +64,16 @@ class Reader
         $workflowName = $parsed['name'];
         $jobs         = $parsed['jobs'];
 
+        $localJobs = new JobsCollection();
         foreach ($jobs as $jobName => $jobContent) {
-            $jobs[$jobName] = Job::createFromArray($jobName, $jobContent, $fileInfo->getFilename(), $workflowName, $jobName);
+            if (in_array($jobName, $ignoredJobs, true)) {
+                continue;
+            }
+
+            $job = Job::createFromArray($jobName, $jobContent, $fileInfo->getFilename(), $workflowName, $jobName);
+            $localJobs->addJob($job);
         }
 
-        return new JobsCollection($jobs);
+        return $localJobs;
     }
 }

--- a/tests/Config/GHMatrixConfigTest.php
+++ b/tests/Config/GHMatrixConfigTest.php
@@ -262,4 +262,29 @@ class GHMatrixConfigTest extends TestCase
 
         $this->assertSame([], $config->getAllOptionalCombinations());
     }
+
+    public function testGetIgnoredJobsReturnsEmptyArrayInitially(): void
+    {
+        $config = new GHMatrixConfig();
+
+        $this->assertSame([], $config->getIgnoredJobs());
+    }
+
+    public function testIgnoreJobAddsTheJobToTheIgnoredList(): void
+    {
+        $config = new GHMatrixConfig();
+        $config->ignoreJob('deploy');
+        $config->ignoreJob('release');
+
+        $this->assertSame(['deploy', 'release'], $config->getIgnoredJobs());
+    }
+
+    public function testIgnoreJobThrowsOnEmptyJobName(): void
+    {
+        $config = new GHMatrixConfig();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The job name cannot be empty.');
+        $config->ignoreJob('');
+    }
 }

--- a/tests/ValueObject/CombinationTest.php
+++ b/tests/ValueObject/CombinationTest.php
@@ -54,7 +54,8 @@ class CombinationTest extends TestCase
 
         $instance = new Combination($combination, $workflowFilename, $workflowName, $job);
 
-        $this->assertSame('artifact-build ()', (string) $instance);
+        // A non-matrix job (empty combination) renders as the bare job name, matching GitHub's context.
+        $this->assertSame('artifact-build', (string) $instance);
     }
 
     public function testGetCombinationReturnsCorrectValues(): void

--- a/tests/ValueObject/JobTest.php
+++ b/tests/ValueObject/JobTest.php
@@ -57,15 +57,21 @@ final class JobTest extends TestCase
         $this->assertEquals($expectedCombinations, $actualCombinations);
     }
 
-    public function testCreateFromArrayThrowsErrorIfStrategyKeyIsMissing(): void
+    public function testCreateFromArrayCreatesNonMatrixJobWhenStrategyIsMissing(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $workflowFilename = 'workflow.yml';
+        $workflowName     = 'Example Workflow';
+        $jobName          = 'build';
 
-        $invalidContent = [
-            // 'strategy' key is missing.
+        // No "strategy" key: a non-matrix job whose single required-check context is the bare job name.
+        $job = Job::createFromArray($jobName, [], $workflowFilename, $workflowName, $jobName);
+
+        $expectedCombinations = [
+            'build' => new Combination([], $workflowFilename, $workflowName, $jobName),
         ];
 
-        Job::createFromArray('test-job', $invalidContent, 'workflow.yml', 'Example Workflow', 'test-job');
+        $this->assertSame($jobName, $job->getName());
+        $this->assertEquals($expectedCombinations, $job->getMatrix()->getCombinations());
     }
 
     public function testCreateFromArrayThrowsErrorIfStrategyKeyIsNotArray(): void
@@ -79,17 +85,26 @@ final class JobTest extends TestCase
         Job::createFromArray('test-job', $invalidContent, 'workflow.yml', 'Example Workflow', 'test-job');
     }
 
-    public function testCreateFromArrayThrowsErrorIfMatrixKeyIsMissing(): void
+    public function testCreateFromArrayCreatesNonMatrixJobWhenMatrixIsMissing(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $workflowFilename = 'workflow.yml';
+        $workflowName     = 'Example Workflow';
+        $jobName          = 'build';
 
-        $invalidContent = [
+        // A "strategy" without "matrix" (e.g. only fail-fast) is still a non-matrix job.
+        $content = [
             'strategy' => [
-                // 'matrix' key is missing.
+                'fail-fast' => false,
             ],
         ];
 
-        Job::createFromArray('test-job', $invalidContent, 'workflow.yml', 'Example Workflow', 'test-job');
+        $job = Job::createFromArray($jobName, $content, $workflowFilename, $workflowName, $jobName);
+
+        $expectedCombinations = [
+            'build' => new Combination([], $workflowFilename, $workflowName, $jobName),
+        ];
+
+        $this->assertEquals($expectedCombinations, $job->getMatrix()->getCombinations());
     }
 
     public function testCreateFromArrayThrowsErrorIfMatrixKeyIsNotArray(): void

--- a/tests/ValueObject/MatrixTest.php
+++ b/tests/ValueObject/MatrixTest.php
@@ -57,7 +57,8 @@ class MatrixTest extends TestCase
 
     public function testCreateFromArrayWithEmptyMatrixCreatesAtLeastOneEmptyCombination(): void
     {
-        $expectedCombinationKey = 'rector ()';
+        // An empty matrix yields a single empty combination, rendered as the bare job name.
+        $expectedCombinationKey = 'rector';
         $expectedCombination    = new Combination([], 'rector.yml', 'Test Rector Workflow', 'rector');
 
         $matrix = Matrix::createFromArray([], 'rector.yml', 'Test Rector Workflow', 'rector');

--- a/tests/Workflow/ReaderTest.php
+++ b/tests/Workflow/ReaderTest.php
@@ -103,6 +103,63 @@ class ReaderTest extends TestCase
         unlink($fileInfo->getPathname());
     }
 
+    public function testCreateFromYamlCreatesBareNameContextForNonMatrixJob(): void
+    {
+        // A realistic non-matrix workflow (like the monorepo's copilot-setup-steps / next-build): no
+        // strategy, so its single required-check context is the bare job name.
+        $yamlContent = <<<YAML
+            name: Build
+            on: [push]
+            jobs:
+              build:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: Checkout
+                    uses: actions/checkout@v3
+            YAML;
+
+        $fileInfo = $this->createTempFile($yamlContent);
+
+        $reader         = new Reader();
+        $jobsCollection = $reader->createFromYaml($fileInfo);
+        $combinations   = $jobsCollection->getJob('build')->getMatrix()->getCombinations();
+
+        $this->assertCount(1, $combinations);
+        // The combination is keyed by its context string: bare "build", no "(...)" suffix.
+        $this->assertArrayHasKey('build', $combinations);
+
+        unlink($fileInfo->getPathname());
+    }
+
+    public function testCreateFromYamlSkipsIgnoredJobs(): void
+    {
+        $yamlContent = <<<YAML
+            name: CI
+            on: [push]
+            jobs:
+              phpunit:
+                strategy:
+                  matrix:
+                    php: [ '8.3', '8.4' ]
+                steps:
+                  - uses: actions/checkout@v3
+              deploy:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: actions/checkout@v3
+            YAML;
+
+        $fileInfo = $this->createTempFile($yamlContent);
+
+        $reader         = new Reader();
+        $jobsCollection = $reader->createFromYaml($fileInfo, ['deploy']);
+
+        $this->assertTrue($jobsCollection->hasJob('phpunit'));
+        $this->assertFalse($jobsCollection->hasJob('deploy'));
+
+        unlink($fileInfo->getPathname());
+    }
+
     public function testReadProcessesValidWorkflowsSuccessfully(): void
     {
         $phpCsWorkflowContent = <<<YAML


### PR DESCRIPTION
## Stack context

Base of the 2-PR "stack B": **handle non-matrix jobs (this)** → preserve external/non-workflow checks (#56). The next PR reuses the bare-name context introduced here.

## What

Stop crashing on jobs without a `strategy.matrix`; model each as **one** required check whose context is the **bare job name**. Add `ignoreJob()` to exclude jobs from the computed set.

## Why

Real monorepos have non-matrix jobs (`build`, `copilot-setup-steps`, `next-build`); `Job::createFromArray` threw on them and crashed the tool. GitHub names a non-matrix job's required check by the **bare job name** (no `(...)`). A naive empty combination would render `build ()` and fail to match → wrongful removal.

## Changes

- `Combination::__toString`: an empty combination renders as the bare job name (no parens).
- `Job::createFromArray`: no `strategy`, or a `strategy` without `matrix`, → a non-matrix job (a single empty / bare-name combination). Still throws on a malformed `strategy`/`matrix` (present but not an array).
- `GHMatrixConfig`: `ignoreJob()` / `getIgnoredJobs()`; `Reader::read()` / `createFromYaml()` skip ignored jobs; `AbstractCommand` threads `config.getIgnoredJobs()` into `read()`.
- `Reader`: builds the collection via `addJob()` (no array mutation).
- Tests: bare-name context (golden fixture from a realistic non-matrix workflow), `strategy`-without-`matrix`, `ignoreJob` excludes a job, config `ignoreJob` add/get/empty-throw; the empty-matrix/empty-combination assertions now expect the bare name.
- README: documents non-matrix jobs and `ignoreJob`.

Closes #55



---
> ↻ Recreates #66 (auto-closed when `master` history was rewritten to strip commit trailers; GitHub blocks reopening a force-pushed closed PR). Same branch `feat-non-matrix-jobs`, same diff. Base of stacked PR #67.
