### PR TITLE
feat: expand "matrix.include" into the generated combinations

### DIFF
--- a/.baseline-phpstan.neon
+++ b/.baseline-phpstan.neon
@@ -275,3 +275,21 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: tests/ValueObject/MatrixTest.php
+
+		-
+			message: '#^Parameter \#1 \$excludedCombinations of static method Aerendir\\Bin\\GitHubActionsMatrix\\ValueObject\\Matrix\:\:prepareExcludedCombinations\(\) expects array\<array\<string, string\>\>, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/ValueObject/Matrix.php
+
+		-
+			message: '#^Parameter \#1 \$matrix of static method Aerendir\\Bin\\GitHubActionsMatrix\\ValueObject\\Matrix\:\:generateCombinations\(\) expects array\<string, array\<string\>\>, array\<string, mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/ValueObject/Matrix.php
+
+		-
+			message: '#^Parameter \#2 \$includeEntries of static method Aerendir\\Bin\\GitHubActionsMatrix\\ValueObject\\Matrix\:\:applyIncludes\(\) expects array\<mixed\>, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/ValueObject/Matrix.php

--- a/README.md
+++ b/README.md
@@ -101,6 +101,29 @@ Before applying any change, `sync` shows the plan and asks for confirmation. Pas
 
 To **verify** alignment in CI without changing anything, use `sync --check`: it is read-only and encodes the result in the exit code — `0` if the branch protection matches the workflows, `1` if it drifts, `2` on error (bad token, network, parse). It needs a token with read access to the branch protection.
 
+#### Matrix expansion (`include` / `exclude`)
+
+The tool expands `strategy.matrix` into the same required-check contexts GitHub generates, honouring both `exclude` and `include` with GitHub's documented semantics (see GitHub's docs: [Using a matrix for your jobs](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs), in particular [Excluding matrix configurations](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#excluding-matrix-configurations) and [Expanding or adding matrix configurations](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations)):
+
+- **`exclude`** removes the matching combinations from the cartesian product.
+- **`include`** is applied **after** `exclude`, processing its entries **in order**. An entry is merged into every base combination it does not conflict with — it may not overwrite an **original** matrix value, but it may add new keys or overwrite values added by an earlier `include` entry, and a single entry can extend many combinations. An entry that fits no base combination becomes a **new** combination. An `include`-only matrix (no other keys) produces exactly one combination per entry.
+
+```yaml
+strategy:
+  matrix:
+    fruit: [apple, pear]
+    animal: [cat, dog]
+    include:
+      - color: green
+      - color: pink
+        animal: cat
+      - fruit: apple
+        shape: circle
+      - fruit: banana
+```
+
+resolves to the contexts `job (apple, cat, pink, circle)`, `job (apple, dog, green, circle)`, `job (pear, cat, pink)`, `job (pear, dog, green)` and `job (banana)` — matching GitHub exactly.
+
 ### Configuration File
 
 To avoid repeatedly providing the same options, you can create a configuration file `gh-actions-matrix.php` in your project root.

--- a/src/ValueObject/Matrix.php
+++ b/src/ValueObject/Matrix.php
@@ -36,16 +36,27 @@ final class Matrix
      */
     public static function createFromArray(array $matrix, string $workflowFilename, string $workflowName, string $job): self
     {
-        /** @phpstan-ignore argument.type */
         $excludedCombinations = self::prepareExcludedCombinations($matrix['exclude'] ?? [], $workflowFilename, $workflowName, $job);
         unset($matrix['exclude']);
 
-        /** @phpstan-ignore argument.type */
+        // "include" is applied after "exclude": pull it out before generating the cartesian product so it is
+        // not mistaken for a matrix dimension. The original dimension keys (what is left now) drive whether an
+        // include entry may merge into a base combination or must become a new one.
+        $includeEntries     = $matrix['include'] ?? [];
+        unset($matrix['include']);
+        $originalMatrixKeys = array_keys($matrix);
+
         $combinations = self::generateCombinations($matrix, $workflowFilename, $workflowName, $job);
 
         $filteredCombinations = self::filterOutExcludedCombinations($combinations, $excludedCombinations);
 
-        return new self($filteredCombinations);
+        if ([] === $includeEntries) {
+            return new self($filteredCombinations);
+        }
+
+        $withIncludes = self::applyIncludes($filteredCombinations, $includeEntries, $originalMatrixKeys, $workflowFilename, $workflowName, $job);
+
+        return new self($withIncludes);
     }
 
     /**
@@ -135,5 +146,110 @@ final class Matrix
         }
 
         return $filteredCombinations;
+    }
+
+    /**
+     * Implements GitHub's documented "include" algorithm, applied after "exclude" and processing entries in
+     * order. Each entry merges into every base combination it does not conflict with — it may not overwrite an
+     * ORIGINAL matrix value, though it may overwrite a value added by an earlier include, and a single entry
+     * can touch many combinations. An entry that fits no base combination becomes a new combination; new
+     * combinations are not themselves candidates for later include merges. When the matrix declares no real
+     * dimensions (include-only), there is no base to merge into, so every entry is a standalone combination.
+     *
+     * @param array<string, Combination> $baseCombinations   the post-exclude combinations
+     * @param array<array-key, mixed>    $includeEntries     raw "include" entries as read from the YAML
+     * @param array<int, string>         $originalMatrixKeys
+     *
+     * @return array<string, Combination>
+     */
+    private static function applyIncludes(array $baseCombinations, array $includeEntries, array $originalMatrixKeys, string $workflowFilename, string $workflowName, string $job): array
+    {
+        // Work on plain value-maps so include entries can merge in declaration order; Combinations are rebuilt
+        // at the end. The synthetic single empty combination produced for a dimension-less matrix is not a real
+        // base, so it is dropped here when there are no original keys.
+        $baseValues = [];
+        if ([] !== $originalMatrixKeys) {
+            foreach ($baseCombinations as $combination) {
+                $baseValues[] = self::normalizeStringMap($combination->getCombination());
+            }
+        }
+
+        $extraValues = [];
+        foreach ($includeEntries as $includeEntry) {
+            if (false === is_array($includeEntry)) {
+                throw new \InvalidArgumentException('Each "include" entry must be an array.');
+            }
+
+            $includeEntry = self::normalizeStringMap($includeEntry);
+
+            $merged = false;
+            foreach ($baseValues as $index => $baseCombination) {
+                if (false === self::includeFitsCombination($includeEntry, $baseCombination, $originalMatrixKeys)) {
+                    continue;
+                }
+
+                // Original keys already match, so this only inserts/overwrites added keys while preserving the
+                // existing key order (PHP keeps the position of an overwritten key, appends a new one).
+                foreach ($includeEntry as $key => $value) {
+                    $baseValues[$index][$key] = $value;
+                }
+
+                $merged = true;
+            }
+
+            if (false === $merged) {
+                $extraValues[] = $includeEntry;
+            }
+        }
+
+        $result = [];
+        foreach ([...$baseValues, ...$extraValues] as $values) {
+            $combination                   = new Combination($values, $workflowFilename, $workflowName, $job);
+            $result[(string) $combination] = $combination;
+        }
+
+        return $result;
+    }
+
+    /**
+     * An include entry fits a base combination when it does not overwrite any original matrix value: every key
+     * it shares with the original dimensions must carry the same value. Added (non-dimension) keys never clash.
+     *
+     * @param array<string, string> $includeEntry
+     * @param array<string, string> $baseCombination
+     * @param array<int, string>    $originalMatrixKeys
+     */
+    private static function includeFitsCombination(array $includeEntry, array $baseCombination, array $originalMatrixKeys): bool
+    {
+        foreach ($includeEntry as $key => $value) {
+            if (false === in_array($key, $originalMatrixKeys, true)) {
+                continue;
+            }
+
+            if (false === array_key_exists($key, $baseCombination) || $baseCombination[$key] !== $value) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<array-key, mixed> $map
+     *
+     * @return array<string, string>
+     */
+    private static function normalizeStringMap(array $map): array
+    {
+        $normalized = [];
+        foreach ($map as $key => $value) {
+            if (false === is_scalar($value)) {
+                throw new \InvalidArgumentException('The "include" values must be scalar.');
+            }
+
+            $normalized[(string) $key] = (string) $value;
+        }
+
+        return $normalized;
     }
 }

--- a/tests/ValueObject/MatrixTest.php
+++ b/tests/ValueObject/MatrixTest.php
@@ -159,6 +159,162 @@ class MatrixTest extends TestCase
         Matrix::createFromArray($invalidMatrixInput, 'rector.yml', 'Test Rector Workflow', 'rector');
     }
 
+    /**
+     * Golden fixture: GitHub's own documented "include" example
+     * (https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations)
+     * with its published resolved output. This is the anchor for the include algorithm.
+     */
+    public function testCreateFromArrayResolvesGitHubDocumentedIncludeExample(): void
+    {
+        $matrixInput = [
+            'fruit'   => ['apple', 'pear'],
+            'animal'  => ['cat', 'dog'],
+            'include' => [
+                ['color' => 'green'],
+                ['color' => 'pink', 'animal' => 'cat'],
+                ['fruit' => 'apple', 'shape' => 'circle'],
+                ['fruit' => 'banana'],
+                ['fruit' => 'banana', 'animal' => 'cat'],
+            ],
+        ];
+
+        $matrix       = Matrix::createFromArray($matrixInput, 'build.yml', 'Build', 'build');
+        $combinations = $matrix->getCombinations();
+
+        $expected = [
+            'build (apple, cat, pink, circle)',
+            'build (apple, dog, green, circle)',
+            'build (pear, cat, pink)',
+            'build (pear, dog, green)',
+            'build (banana)',
+            'build (banana, cat)',
+        ];
+
+        $this->assertSame($expected, array_keys($combinations));
+    }
+
+    public function testIncludeAddsAKeyToEveryCombinationWhenItDoesNotOverwriteOriginalValues(): void
+    {
+        $matrixInput = [
+            'php'     => ['8.3', '8.4'],
+            'include' => [
+                ['coverage' => 'xdebug'],
+            ],
+        ];
+
+        $matrix       = Matrix::createFromArray($matrixInput, 'phpunit.yml', 'PHPUnit', 'phpunit');
+        $combinations = $matrix->getCombinations();
+
+        $this->assertCount(2, $combinations);
+        $this->assertArrayHasKey('phpunit (8.3, xdebug)', $combinations);
+        $this->assertArrayHasKey('phpunit (8.4, xdebug)', $combinations);
+    }
+
+    public function testIncludeEntryThatFitsNoCombinationBecomesANewCombination(): void
+    {
+        $matrixInput = [
+            'php'     => ['8.3', '8.4'],
+            'include' => [
+                ['php' => '8.2'],
+            ],
+        ];
+
+        $matrix       = Matrix::createFromArray($matrixInput, 'phpunit.yml', 'PHPUnit', 'phpunit');
+        $combinations = $matrix->getCombinations();
+
+        $this->assertCount(3, $combinations);
+        $this->assertArrayHasKey('phpunit (8.3)', $combinations);
+        $this->assertArrayHasKey('phpunit (8.4)', $combinations);
+        $this->assertArrayHasKey('phpunit (8.2)', $combinations);
+    }
+
+    public function testIncludeOnlyMatrixYieldsOneCombinationPerEntry(): void
+    {
+        $matrixInput = [
+            'include' => [
+                ['php' => '8.3', 'os' => 'ubuntu-latest'],
+                ['php' => '8.4', 'os' => 'windows-latest'],
+            ],
+        ];
+
+        $matrix       = Matrix::createFromArray($matrixInput, 'phpunit.yml', 'PHPUnit', 'phpunit');
+        $combinations = $matrix->getCombinations();
+
+        $this->assertCount(2, $combinations);
+        $this->assertArrayHasKey('phpunit (8.3, ubuntu-latest)', $combinations);
+        $this->assertArrayHasKey('phpunit (8.4, windows-latest)', $combinations);
+    }
+
+    public function testIncludeIsAppliedAfterExclude(): void
+    {
+        $matrixInput = [
+            'php'     => ['8.3', '8.4'],
+            'symfony' => ['~6.4', '~7.4'],
+            'exclude' => [
+                ['php' => '8.3', 'symfony' => '~7.4'],
+            ],
+            'include' => [
+                ['php' => '8.3', 'symfony' => '~6.4', 'coverage' => 'xdebug'],
+            ],
+        ];
+
+        $matrix       = Matrix::createFromArray($matrixInput, 'phpunit.yml', 'PHPUnit', 'phpunit');
+        $combinations = $matrix->getCombinations();
+
+        // 4 base - 1 excluded = 3, and the include merges into the surviving (8.3, ~6.4) combination.
+        $this->assertCount(3, $combinations);
+        $this->assertArrayHasKey('phpunit (8.3, ~6.4, xdebug)', $combinations);
+        $this->assertArrayHasKey('phpunit (8.4, ~6.4)', $combinations);
+        $this->assertArrayHasKey('phpunit (8.4, ~7.4)', $combinations);
+        $this->assertArrayNotHasKey('phpunit (8.3, ~7.4)', $combinations);
+    }
+
+    public function testIncludeAddedKeyCanBeOverwrittenByALaterEntry(): void
+    {
+        $matrixInput = [
+            'php'     => ['8.3'],
+            'include' => [
+                ['coverage' => 'none'],
+                ['php' => '8.3', 'coverage' => 'xdebug'],
+            ],
+        ];
+
+        $matrix       = Matrix::createFromArray($matrixInput, 'phpunit.yml', 'PHPUnit', 'phpunit');
+        $combinations = $matrix->getCombinations();
+
+        // The second entry overwrites the "coverage" added by the first (added keys may be overwritten).
+        $this->assertCount(1, $combinations);
+        $this->assertArrayHasKey('phpunit (8.3, xdebug)', $combinations);
+    }
+
+    public function testIncludeWithNonArrayEntryThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $matrixInput = [
+            'php'     => ['8.3'],
+            'include' => ['not-an-array'],
+        ];
+
+        Matrix::createFromArray($matrixInput, 'phpunit.yml', 'PHPUnit', 'phpunit');
+    }
+
+    public function testIncludeWithNonScalarValueThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "include" values must be scalar.');
+
+        $matrixInput = [
+            'php'     => ['8.3'],
+            'include' => [
+                // A nested array is not a valid include value: it cannot become part of a context string.
+                ['php' => ['8.3', '8.4']],
+            ],
+        ];
+
+        Matrix::createFromArray($matrixInput, 'phpunit.yml', 'PHPUnit', 'phpunit');
+    }
+
     public function testMergeWithNonOverlappingCombinations(): void
     {
         $matrix1Combinations = [


### PR DESCRIPTION
## Stack Context

Driver: TrustBack.Me `#5382` — make `sync` safe by computing the same required-check contexts GitHub does. This stack closes the last two open feature issues:

1. **this PR** — `#57` expand `matrix.include`
2. `#73` — `#58` handle non-derivable contexts (stacked on this)

## What?

Implements GitHub's documented `matrix.include` algorithm in `Matrix::createFromArray()`.

## Why?

`include` was not handled at all: the key leaked into `generateCombinations()` and was treated as a matrix dimension, producing garbage combinations and an "array to string conversion" crash. So `include` did not merely lack support — it **broke** parsing.

The algorithm is applied **after** `exclude`, processing entries **in order**:

- an entry merges into every base combination it does not conflict with — it may not overwrite an **original** matrix value, but may add new keys or overwrite values added by an earlier `include`, and a single entry can touch many combinations;
- an entry that fits no base combination becomes a **new** combination (new combinations are not candidates for later merges);
- an `include`-only matrix yields exactly one combination per entry.

## Tests

Golden fixture = GitHub's own documented `fruit`/`animal`/`color`/`shape` example asserted against its published resolved output, plus targeted cases (add-to-all, new-combination, include-only, after-exclude, added-key-overwrite, invalid entry). README updated. Full gate green (phpstan/psalm/rector/php-cs-fixer/phpunit).
