### PR TITLE
feat: handle status-check contexts that are not statically derivable

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,22 @@ strategy:
 
 resolves to the contexts `job (apple, cat, pink, circle)`, `job (apple, dog, green, circle)`, `job (pear, cat, pink)`, `job (pear, dog, green)` and `job (banana)` — matching GitHub exactly.
 
+#### Non-derivable contexts (interpolated names / dynamic matrices)
+
+Some required-check context names **cannot be derived statically** from the YAML, so the tool must not guess them:
+
+- an interpolated job **name**, e.g. `name: build ${{ matrix.os }}` — GitHub shows the resolved value, not `job (values)`;
+- a **dynamic matrix**, e.g. `matrix: ${{ fromJson(needs.setup.outputs.matrix) }}` or matrix keys/values built from expressions — the values do not exist as literal arrays in the file (and may even be branch-dependent).
+
+When such a job is detected, the tool **does not compute a (wrong) context** for it and prints a clear **warning** before any change. Because it cannot know the real context name, `sync` would otherwise risk removing it, so you have two clean options:
+
+1. **Declare the real context name** so `sync` preserves it (it is treated like an external required check and never removed):
+   ```php
+   $config->addRequiredCheck('build ubuntu-latest');
+   $config->addRequiredCheck('build windows-latest');
+   ```
+2. **Use a static "gate" job** (recommended for dynamic matrices): a single job with a static name that `needs:` the dynamic matrix job, and make *that* gate job the required check. The tool derives the gate job's context normally, and it stays green only when the whole matrix passes.
+
 ### Configuration File
 
 To avoid repeatedly providing the same options, you can create a configuration file `gh-actions-matrix.php` in your project root.

--- a/src/Console/Command/SyncCommand.php
+++ b/src/Console/Command/SyncCommand.php
@@ -100,6 +100,11 @@ final class SyncCommand extends AbstractCommand
             throw $throwable;
         }
 
+        $warnings = $this->getLocalJobs()->getWarnings();
+        if ([] !== $warnings) {
+            $io->warning(['Some required-check contexts cannot be derived from the workflows:', ...$warnings]);
+        }
+
         $repoUsername               = $this->getRepoUsername();
         $repoName                   = $this->getRepoName();
         $localJobs                  = $this->getLocalJobs();

--- a/src/ValueObject/JobsCollection.php
+++ b/src/ValueObject/JobsCollection.php
@@ -18,6 +18,9 @@ class JobsCollection
     /** @var array<string> $ids */
     private array $ids = [];
 
+    /** @var array<int, string> */
+    private array $warnings = [];
+
     /**
      * @param array<string, Job> $jobs
      */
@@ -30,6 +33,27 @@ class JobsCollection
         foreach ($collection->getJobs() as $job) {
             $this->addOrMergeJob($job);
         }
+
+        foreach ($collection->getWarnings() as $warning) {
+            $this->addWarning($warning);
+        }
+    }
+
+    /**
+     * Records a non-fatal warning gathered while reading the workflows (e.g. a job whose required-check
+     * context cannot be derived statically). Surfaced to the user before any change is applied.
+     */
+    public function addWarning(string $warning): void
+    {
+        $this->warnings[] = $warning;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getWarnings(): array
+    {
+        return $this->warnings;
     }
 
     public function addOrMergeJob(Job $job): void

--- a/src/Workflow/NonDerivableContextDetector.php
+++ b/src/Workflow/NonDerivableContextDetector.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Aerendir GitHub Actions Matrix.
+ *
+ * Copyright (c) Adamo Aerendir Crespi <aerendir@serendipityhq.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Aerendir\Bin\GitHubActionsMatrix\Workflow;
+
+/**
+ * Detects jobs whose required-check context name(s) cannot be derived statically from the workflow YAML.
+ *
+ * Two cases make a context non-derivable:
+ *   1. an interpolated job `name:` (e.g. `name: build ${{ matrix.os }}`): GitHub shows the resolved value,
+ *      not the literal `job (values)` the tool would compute;
+ *   2. a dynamic matrix (`matrix: ${{ fromJson(...) }}`, or matrix keys/values built from expressions): the
+ *      values do not exist as literal arrays in the file, so the combinations cannot be computed at all.
+ *
+ * In both cases the tool must NOT compute a (wrong) context; the caller warns the user and relies on the
+ * "required checks" preservation so the real context name can be declared instead of being miscomputed.
+ */
+final class NonDerivableContextDetector
+{
+    private const string EXPRESSION_MARKER = '${{';
+    private const string FROM_JSON_MARKER  = 'fromJson';
+
+    /**
+     * Returns a human-readable reason when the job's context(s) cannot be derived statically, or null when
+     * they are fully derivable.
+     *
+     * @param array<array-key, mixed> $jobContent the raw job definition as read from the YAML
+     */
+    public function detect(array $jobContent): ?string
+    {
+        if (array_key_exists('name', $jobContent) && $this->containsExpression($jobContent['name'])) {
+            return 'its "name" is built from an expression, so the real check context uses the interpolated value';
+        }
+
+        $strategy = $jobContent['strategy'] ?? null;
+        if (false === is_array($strategy) || false === array_key_exists('matrix', $strategy)) {
+            return null;
+        }
+
+        $matrix = $strategy['matrix'];
+
+        // `matrix: ${{ fromJson(...) }}` — the whole matrix is an expression: there are no literal values.
+        if (false === is_array($matrix)) {
+            return $this->containsExpression($matrix)
+                ? 'its matrix is generated dynamically from an expression (no literal values to expand)'
+                : null;
+        }
+
+        if ($this->containsExpression($matrix)) {
+            return 'its matrix uses expression-based keys or values (no literal values to expand)';
+        }
+
+        return null;
+    }
+
+    /**
+     * True when the value (or, recursively, any of its keys/leaves) carries a GitHub expression or a
+     * `fromJson` call — the markers that make a context non-derivable.
+     */
+    private function containsExpression(mixed $value): bool
+    {
+        if (is_string($value)) {
+            return str_contains($value, self::EXPRESSION_MARKER) || str_contains($value, self::FROM_JSON_MARKER);
+        }
+
+        if (is_array($value)) {
+            foreach ($value as $key => $item) {
+                if (is_string($key) && (str_contains($key, self::EXPRESSION_MARKER) || str_contains($key, self::FROM_JSON_MARKER))) {
+                    return true;
+                }
+
+                if ($this->containsExpression($item)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Workflow/Reader.php
+++ b/src/Workflow/Reader.php
@@ -22,7 +22,7 @@ use function Safe\file_get_contents;
 
 class Reader
 {
-    public function __construct(private readonly Finder $finder = new Finder())
+    public function __construct(private readonly Finder $finder = new Finder(), private readonly NonDerivableContextDetector $nonDerivableContextDetector = new NonDerivableContextDetector())
     {
     }
 
@@ -76,6 +76,23 @@ class Reader
         foreach ($jobs as $jobName => $jobContent) {
             if (in_array($jobName, $ignoredJobs, true)) {
                 continue;
+            }
+
+            // Some contexts cannot be derived statically (interpolated job name, dynamic/fromJson matrix):
+            // computing one would produce a wrong context that sync might wrongly remove/recreate. Warn and
+            // skip, leaving the real context to be preserved via a declared required check or a gate job.
+            if (is_array($jobContent)) {
+                $nonDerivableReason = $this->nonDerivableContextDetector->detect($jobContent);
+                if (null !== $nonDerivableReason) {
+                    $localJobs->addWarning(sprintf(
+                        'Job "%s" (workflow "%s"): %s. Its real check context cannot be computed; declare it with addRequiredCheck() (or use a static "gate" job) so sync preserves it instead of removing it.',
+                        is_scalar($jobName) ? (string) $jobName : '',
+                        is_scalar($workflowName) ? (string) $workflowName : '',
+                        $nonDerivableReason,
+                    ));
+
+                    continue;
+                }
             }
 
             $job = Job::createFromArray($jobName, $jobContent, $fileInfo->getFilename(), $workflowName, $jobName);

--- a/tests/Console/Command/SyncCommandTest.php
+++ b/tests/Console/Command/SyncCommandTest.php
@@ -16,6 +16,8 @@ namespace Aerendir\Bin\GitHubActionsMatrix\Tests\Console\Command;
 use Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options\GitHubTokenCommandOption;
 use Aerendir\Bin\GitHubActionsMatrix\Console\Command\Params\Options\GitHubUsernameCommandOption;
 use Aerendir\Bin\GitHubActionsMatrix\Console\Command\SyncCommand;
+use Aerendir\Bin\GitHubActionsMatrix\Workflow\Finder;
+use Aerendir\Bin\GitHubActionsMatrix\Workflow\Reader as WorkflowsReader;
 use Github\Api\Repo;
 use Github\Api\Repository\Protection;
 use Github\Client;
@@ -155,6 +157,23 @@ class SyncCommandTest extends CommandTestCase
         $this->assertSame(2, $commandTester->getStatusCode());
     }
 
+    public function testExecuteSurfacesNonDerivableContextWarnings(): void
+    {
+        $commandTester = $this->createSyncCommandTesterWithNonDerivableJob();
+
+        $commandTester->execute([
+            '--' . GitHubUsernameCommandOption::NAME => self::TEST_USERNAME,
+            '--' . GitHubTokenCommandOption::NAME    => self::TEST_TOKEN,
+            '--dry-run'                              => true,
+        ]);
+
+        $output = $commandTester->getDisplay();
+
+        $this->assertStringContainsString('cannot be derived', $output);
+        $this->assertStringContainsString('dynamic', $output);
+        $this->assertStringContainsString('addRequiredCheck()', $output);
+    }
+
     public function testErrorPropagatesWhenNotInCheckMode(): void
     {
         $commandTester = $this->createFailingCommandTester();
@@ -164,6 +183,41 @@ class SyncCommandTest extends CommandTestCase
             '--' . GitHubUsernameCommandOption::NAME => self::TEST_USERNAME,
             '--' . GitHubTokenCommandOption::NAME    => self::TEST_TOKEN,
         ]);
+    }
+
+    /**
+     * Builds a tester whose workflows include a job with a dynamic (`fromJson`) matrix, so the read step
+     * records a non-derivable-context warning that the command must surface to the user.
+     */
+    private function createSyncCommandTesterWithNonDerivableJob(): CommandTester
+    {
+        $workflowContent = <<<YAML
+            name: CI
+            on: [push]
+            jobs:
+              dynamic:
+                strategy:
+                  matrix:
+                    os: \${{ fromJson(needs.setup.outputs.os) }}
+                steps:
+                  - uses: actions/checkout@v3
+            YAML;
+
+        $fileInfo = $this->createTempFile($workflowContent, 'ci');
+
+        $finder = $this->createMock(Finder::class);
+        $finder->method('getWorkflows')->willReturn(new \ArrayIterator([$fileInfo]));
+
+        $command = new SyncCommand(
+            repoReader: $this->createMockReader(self::TEST_REPO),
+            workflowsReader: new WorkflowsReader($finder),
+            githubClient: $this->createMockGitHubClient(),
+        );
+
+        $application = new Application();
+        $application->addCommand($command);
+
+        return new CommandTester($command);
     }
 
     private function createSyncCommandTester(): CommandTester

--- a/tests/ValueObject/JobsCollectionTest.php
+++ b/tests/ValueObject/JobsCollectionTest.php
@@ -20,6 +20,30 @@ use PHPUnit\Framework\TestCase;
 
 class JobsCollectionTest extends TestCase
 {
+    public function testWarningsAreStoredAndExposed(): void
+    {
+        $collection = new JobsCollection();
+        $this->assertSame([], $collection->getWarnings());
+
+        $collection->addWarning('first warning');
+        $collection->addWarning('second warning');
+
+        $this->assertSame(['first warning', 'second warning'], $collection->getWarnings());
+    }
+
+    public function testMergeCollectionAlsoMergesWarnings(): void
+    {
+        $first = new JobsCollection();
+        $first->addWarning('from first');
+
+        $second = new JobsCollection();
+        $second->addWarning('from second');
+
+        $first->mergeCollection($second);
+
+        $this->assertSame(['from first', 'from second'], $first->getWarnings());
+    }
+
     public function testAddOrMergeJobAddsNewJob(): void
     {
         $matrix     = new Matrix([]);

--- a/tests/Workflow/NonDerivableContextDetectorTest.php
+++ b/tests/Workflow/NonDerivableContextDetectorTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Aerendir GitHub Actions Matrix.
+ *
+ * Copyright (c) Adamo Aerendir Crespi <aerendir@serendipityhq.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Aerendir\Bin\GitHubActionsMatrix\Tests\Workflow;
+
+use Aerendir\Bin\GitHubActionsMatrix\Workflow\NonDerivableContextDetector;
+use PHPUnit\Framework\TestCase;
+
+final class NonDerivableContextDetectorTest extends TestCase
+{
+    public function testReturnsNullForAStaticNonMatrixJob(): void
+    {
+        $detector = new NonDerivableContextDetector();
+
+        $this->assertNull($detector->detect([
+            'runs-on' => 'ubuntu-latest',
+        ]));
+    }
+
+    public function testReturnsNullForAStaticMatrixJob(): void
+    {
+        $detector = new NonDerivableContextDetector();
+
+        $this->assertNull($detector->detect([
+            'strategy' => [
+                'matrix' => [
+                    'php' => ['8.3', '8.4'],
+                    'os'  => ['ubuntu-latest', 'windows-latest'],
+                ],
+            ],
+        ]));
+    }
+
+    public function testReturnsNullForAStaticNameWithoutExpression(): void
+    {
+        $detector = new NonDerivableContextDetector();
+
+        $this->assertNull($detector->detect([
+            'name'    => 'Build the project',
+            'runs-on' => 'ubuntu-latest',
+        ]));
+    }
+
+    public function testDetectsAnInterpolatedJobName(): void
+    {
+        $detector = new NonDerivableContextDetector();
+
+        $reason = $detector->detect([
+            'name'     => 'build ${{ matrix.os }}',
+            'strategy' => [
+                'matrix' => ['os' => ['ubuntu-latest', 'windows-latest']],
+            ],
+        ]);
+
+        $this->assertNotNull($reason);
+        $this->assertStringContainsString('name', $reason);
+    }
+
+    public function testDetectsAFullyDynamicMatrix(): void
+    {
+        $detector = new NonDerivableContextDetector();
+
+        $reason = $detector->detect([
+            'strategy' => [
+                'matrix' => '${{ fromJson(needs.setup.outputs.matrix) }}',
+            ],
+        ]);
+
+        $this->assertNotNull($reason);
+        $this->assertStringContainsString('matrix', $reason);
+    }
+
+    public function testDetectsAnExpressionInsideAMatrixValue(): void
+    {
+        $detector = new NonDerivableContextDetector();
+
+        $reason = $detector->detect([
+            'strategy' => [
+                'matrix' => [
+                    'os'  => '${{ fromJson(needs.setup.outputs.os) }}',
+                    'php' => ['8.3'],
+                ],
+            ],
+        ]);
+
+        $this->assertNotNull($reason);
+    }
+
+    public function testDetectsAnExpressionUsedAsAMatrixKey(): void
+    {
+        $detector = new NonDerivableContextDetector();
+
+        $reason = $detector->detect([
+            'strategy' => [
+                'matrix' => [
+                    '${{ fromJson(needs.setup.outputs.key) }}' => ['a', 'b'],
+                ],
+            ],
+        ]);
+
+        $this->assertNotNull($reason);
+        $this->assertStringContainsString('matrix', $reason);
+    }
+
+    public function testDetectsAFromJsonValueWithoutTheExpressionWrapper(): void
+    {
+        $detector = new NonDerivableContextDetector();
+
+        $reason = $detector->detect([
+            'strategy' => [
+                'matrix' => [
+                    'include' => 'fromJson(something)',
+                ],
+            ],
+        ]);
+
+        $this->assertNotNull($reason);
+    }
+
+    public function testReturnsNullWhenStrategyHasNoMatrix(): void
+    {
+        $detector = new NonDerivableContextDetector();
+
+        $this->assertNull($detector->detect([
+            'strategy' => [
+                'fail-fast' => false,
+            ],
+        ]));
+    }
+}

--- a/tests/Workflow/ReaderTest.php
+++ b/tests/Workflow/ReaderTest.php
@@ -212,6 +212,92 @@ class ReaderTest extends TestCase
         unlink($rectorFileInfo->getPathname());
     }
 
+    public function testCreateFromYamlWarnsAndSkipsAJobWithAnInterpolatedName(): void
+    {
+        $yamlContent = <<<YAML
+            name: CI
+            on: [push]
+            jobs:
+              build:
+                name: build \${{ matrix.os }}
+                strategy:
+                  matrix:
+                    os: [ ubuntu-latest, windows-latest ]
+                steps:
+                  - uses: actions/checkout@v3
+            YAML;
+
+        $fileInfo = $this->createTempFile($yamlContent);
+
+        $reader         = new Reader();
+        $jobsCollection = $reader->createFromYaml($fileInfo);
+
+        // The non-derivable job is not added (no miscomputed context) and a clear warning is recorded.
+        $this->assertFalse($jobsCollection->hasJob('build'));
+        $this->assertCount(1, $jobsCollection->getWarnings());
+        $this->assertStringContainsString('build', $jobsCollection->getWarnings()[0]);
+        $this->assertStringContainsString('addRequiredCheck()', $jobsCollection->getWarnings()[0]);
+
+        unlink($fileInfo->getPathname());
+    }
+
+    public function testCreateFromYamlWarnsAndSkipsAJobWithADynamicMatrix(): void
+    {
+        $yamlContent = <<<YAML
+            name: CI
+            on: [push]
+            jobs:
+              test:
+                strategy:
+                  matrix:
+                    os: \${{ fromJson(needs.setup.outputs.os) }}
+                steps:
+                  - uses: actions/checkout@v3
+            YAML;
+
+        $fileInfo = $this->createTempFile($yamlContent);
+
+        $reader         = new Reader();
+        $jobsCollection = $reader->createFromYaml($fileInfo);
+
+        $this->assertFalse($jobsCollection->hasJob('test'));
+        $this->assertCount(1, $jobsCollection->getWarnings());
+
+        unlink($fileInfo->getPathname());
+    }
+
+    public function testCreateFromYamlKeepsDerivableJobsWhileSkippingNonDerivableOnes(): void
+    {
+        $yamlContent = <<<YAML
+            name: CI
+            on: [push]
+            jobs:
+              phpunit:
+                strategy:
+                  matrix:
+                    php: [ '8.3', '8.4' ]
+                steps:
+                  - uses: actions/checkout@v3
+              dynamic:
+                strategy:
+                  matrix:
+                    os: \${{ fromJson(needs.setup.outputs.os) }}
+                steps:
+                  - uses: actions/checkout@v3
+            YAML;
+
+        $fileInfo = $this->createTempFile($yamlContent);
+
+        $reader         = new Reader();
+        $jobsCollection = $reader->createFromYaml($fileInfo);
+
+        $this->assertTrue($jobsCollection->hasJob('phpunit'));
+        $this->assertFalse($jobsCollection->hasJob('dynamic'));
+        $this->assertCount(1, $jobsCollection->getWarnings());
+
+        unlink($fileInfo->getPathname());
+    }
+
     public function testReadInjectsExternalRequiredChecksAsBareNameJobs(): void
     {
         $workflowContent = <<<YAML


### PR DESCRIPTION
## Stack Context

Driver: TrustBack.Me `#5382`. Last of the two open feature issues. Stacked on **#72** (`#57` matrix.include). Builds on the external-required-checks preservation (`#56`/merged).

## What?

Detects required-check contexts that cannot be derived statically from the YAML and refuses to miscompute them.

## Why?

Two cases make a context non-derivable, and computing one produces a wrong context that `sync` would wrongly remove/recreate:

1. **interpolated job name** — `name: build ${{ matrix.os }}`: GitHub shows the resolved value, not `job (values)`;
2. **dynamic matrix** — `matrix: ${{ fromJson(...) }}` or expression-based matrix keys/values: the values are not literal arrays in the file.

A dedicated `NonDerivableContextDetector` flags these. The `Reader` then **skips** the job (no miscomputed context) and records a **warning** (carried on `JobsCollection`); `SyncCommand` surfaces it before any change. Because the real context name cannot be known, the warning points the user to the two clean options:

- declare the real name with `addRequiredCheck()` (reuses the `#56` preservation — never removed), or
- use a static **gate job** that `needs:` the dynamic matrix and is the required check.

So the contexts are never **silently** miscomputed or removed.

## Tests

`NonDerivableContextDetectorTest` (interpolated name, fully-dynamic matrix, expression in value, `fromJson`, static negatives), `Reader` warn-and-skip + keep-derivable cases, `JobsCollection` warnings store/merge, and a `SyncCommand` test asserting the warning is surfaced. README updated (limitation + gate-job recommendation + how to declare). Full gate green.
